### PR TITLE
[PRO-354] bug fix mobile header layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Open_Sans } from "next/font/google";
+import { Source_Sans_3 } from "next/font/google";
 import "@/styles/index.scss";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
@@ -7,7 +7,7 @@ import AuthProvider from "@/components/AuthProvider";
 import { getUser } from "@/lib/session";
 import NotificationArea from "@/components/notifications/NotificationArea";
 
-const font = Open_Sans({ subsets: ["latin"] });
+const font = Source_Sans_3({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Project Protocol",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,9 @@
 import LoginForm from "@/components/login/LoginForm";
+import { headers } from "next/headers";
 
 export default async function Page() {
-  return <LoginForm />;
+  const referrer = headers().get("referer");
+  const path = new URL(referrer || "").pathname;
+
+  return <LoginForm callbackURL={path} />;
 }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -45,15 +45,16 @@ export default async function Menu() {
             >
               <Image
                 priority
+                unoptimized
                 src={icon.src}
                 width="0"
                 height="0"
                 className="me-2"
-                style={{ width: 28, height: 28 }}
+                style={{ width: 25, height: 25 }}
                 alt={"Project Protocol logo"}
               />
               <span
-                className="fs-2 w-100 d-md-inline fw-medium pe-auto text-white"
+                className="fs-md-2  fs-3 w-100 d-md-inline fw-medium pe-auto text-white"
                 style={{ letterSpacing: -0.5 }}
               >
                 Project Protocol

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -50,11 +50,11 @@ export default async function Menu() {
                 width="0"
                 height="0"
                 className="me-2"
-                style={{ width: 25, height: 25 }}
+                style={{ width: 28, height: 28 }}
                 alt={"Project Protocol logo"}
               />
               <span
-                className="fs-md-2  fs-3 w-100 d-md-inline fw-medium pe-auto text-white"
+                className="fs-2 w-100 d-md-inline fw-medium pe-auto text-white"
                 style={{ letterSpacing: -0.5 }}
               >
                 Project Protocol

--- a/src/components/Menu/MobileTabItem.tsx
+++ b/src/components/Menu/MobileTabItem.tsx
@@ -16,17 +16,19 @@ export default function MobileTabItem({
   const isActive = to === "/" ? path === "/" : path.startsWith(to);
 
   return (
-    <a
-      href={to}
-      className={classNames(
-        "d-flex flex-column align-items-center text-decoration-none",
-        {
-          "text-primary": isActive,
-        }
-      )}
-    >
-      {icon}
-      <span>{label}</span>
-    </a>
+    <div className="w-100">
+      <a
+        href={to}
+        className={classNames(
+          "d-flex flex-column align-items-center text-decoration-none",
+          {
+            "text-primary": isActive,
+          }
+        )}
+      >
+        {icon}
+        <span>{label}</span>
+      </a>
+    </div>
   );
 }

--- a/src/components/Menu/MobileTabs.tsx
+++ b/src/components/Menu/MobileTabs.tsx
@@ -7,7 +7,7 @@ import MobileTabItem from "./MobileTabItem";
 export default function MobileTabs() {
   return (
     <Navbar fixed="bottom" className="bg-white shadow shadow-lg d-md-none">
-      <div className="d-flex justify-content-around align-items-center w-100 h-100 py-1">
+      <div className="d-flex align-items-center w-100 h-100 py-1">
         <MobileTabItem icon={<HomeIcon />} label="Home" to="/" />
         <MobileTabItem
           icon={<SearchIcon />}

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -22,7 +22,7 @@ const initialState = {
   errors: {},
 };
 
-export default function LoginForm() {
+export default function LoginForm({ callbackURL }: { callbackURL?: string }) {
   const t = useTranslations();
   const [state, formAction] = useFormState(login, initialState);
 
@@ -30,6 +30,7 @@ export default function LoginForm() {
     <div className="d-block p-4">
       <div className="text-center mb-3">{t("login.loginTitleHelper")}</div>
       <form className="vertical-rhythm" action={formAction}>
+        <input type="hidden" name="callbackURL" value={callbackURL} />
         <Input
           size="lg"
           controlId={`login-email`}

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { createSession } from "../session";
 import { flashError, flashSuccess } from "../flash-messages";
 import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
 
 const apiURL: string = process.env.API_URL || "";
 
@@ -55,4 +56,9 @@ export async function login(prevState: any, formData: FormData) {
   const user = { email, isConfirmed, confirmationSentAt };
   flashSuccess(t("login.success"));
   await createSession(user, apiToken);
+
+  const redirectURL = formData.get("callbackURL");
+  if (redirectURL) {
+    redirect(String(redirectURL));
+  }
 }


### PR DESCRIPTION
## 🛠️ Changes
Grab bag of fixes:

* ~~Tweak font size of brand text for mobile screens~~ Changed font back to Source Sans 3 (matches vitejs, smaller typeface)
* Prevent next/image from trying to optimize brand svg (caused flickering sometimes)
* Make mobile footer tabs equal width
* Redirect logins to original page using path stripped from referrer header.

## 🧪 Testing
* Check out preview using various mobile views
* Try logging in from rate-my-po or an agent page and see that you are redirected back

<img width="414" alt="image" src="https://github.com/ProjectProtocol/project-protocol-nextjs/assets/6488787/8f358c0f-5d69-4eaa-a680-e5d8237572af">
