### PR TITLE
[Pro-355] Login forgot password flow

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,8 +30,8 @@ export default async function RootLayout({
           font.className + " w-100 min-vh-100 p-0 bg-light overflow-y-scroll"
         }
       >
-        <NotificationArea />
         <NextIntlClientProvider messages={messages}>
+          <NotificationArea />
           <AuthProvider user={user}>{children}</AuthProvider>
         </NextIntlClientProvider>
       </body>

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -23,7 +23,7 @@ export default async function Layout({
       <Container fluid>
         <div
           className="m-auto vertical-rhythm"
-          style={{ maxWidth: 336, minHeight: 500 }}
+          style={{ maxWidth: 336, minHeight: 700 }}
         >
           <div className="text-end mb-5">
             <a href="/">
@@ -36,7 +36,7 @@ export default async function Layout({
           <div className="text-center vertical-rhythm">
             <Image
               priority
-              src={icon.src}
+              src={icon}
               width="40"
               height="0"
               className="me-2 h-auto"

--- a/src/app/login/reset-password/page.tsx
+++ b/src/app/login/reset-password/page.tsx
@@ -1,7 +1,0 @@
-export default async function Page() {
-  // Get token from url param
-  // Pass to form
-  // On success, redirect to login
-  // On failure, show error
-  return <div>Reset Password</div>;
-}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -3,7 +3,7 @@ import { getTranslations } from "next-intl/server";
 import Image from "next/image";
 
 export default async function NotFound() {
-  const t = await getTranslations();
+  const t = await getTranslations("home");
   return (
     <div
       className="d-flex justify-content-center align-items-center flex-column"
@@ -11,8 +11,9 @@ export default async function NotFound() {
     >
       <div className="vertical-rhythm text-center">
         <Image src="/images/icon.svg" alt="icon" width={45} height={45} />
-        <h1>{t("shared.notFound")}</h1>
-        <BackLink className="text-underline">{t("shared.back")}</BackLink>
+        <h1>{t("error.notFound")}</h1>
+        <p>{t("error.notFoundMessage")}</p>
+        <BackLink className="text-underline">{t("error.homeLink")}</BackLink>
       </div>
     </div>
   );

--- a/src/app/password_resets/[token]/_components/PasswordResetForm.tsx
+++ b/src/app/password_resets/[token]/_components/PasswordResetForm.tsx
@@ -6,9 +6,12 @@ import Input from "@/components/Input";
 import { useCallback } from "react";
 import AsyncButton from "@/components/AsyncButton";
 import { IPasswordResetsFormState, resetPassword } from "@/lib/actions/account";
+import toast from "react-hot-toast";
+import { useRouter } from "next/navigation";
 
 export default function PasswordResetForm({ token }: { token: string }) {
   const t = useTranslations();
+  const router = useRouter();
   const { register, watch, handleSubmit, getFieldState, formState } =
     useForm<IPasswordResetsFormState>({
       mode: "onSubmit",
@@ -20,7 +23,14 @@ export default function PasswordResetForm({ token }: { token: string }) {
     });
 
   async function onSubmit(data: IPasswordResetsFormState) {
-    await resetPassword(data);
+    const { error } = await resetPassword(data);
+
+    if (error) {
+      toast.error(t(error));
+    } else {
+      toast.success(t("password_reset.resetSuccess"));
+      router.replace("/");
+    }
   }
 
   const validationProps = useCallback(

--- a/src/app/password_resets/[token]/_components/PasswordResetForm.tsx
+++ b/src/app/password_resets/[token]/_components/PasswordResetForm.tsx
@@ -14,7 +14,7 @@ export default function PasswordResetForm({ token }: { token: string }) {
   const router = useRouter();
   const { register, watch, handleSubmit, getFieldState, formState } =
     useForm<IPasswordResetsFormState>({
-      mode: "onSubmit",
+      mode: "onBlur",
       defaultValues: {
         newPassword: "",
         newPasswordConfirm: "",

--- a/src/app/password_resets/[token]/_components/PasswordResetForm.tsx
+++ b/src/app/password_resets/[token]/_components/PasswordResetForm.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { useTranslations } from "next-intl";
+import Input from "@/components/Input";
+import { useCallback } from "react";
+import AsyncButton from "@/components/AsyncButton";
+import { IPasswordResetsFormState, resetPassword } from "@/lib/actions/account";
+
+export default function PasswordResetForm({ token }: { token: string }) {
+  const t = useTranslations();
+  const { register, watch, handleSubmit, getFieldState, formState } =
+    useForm<IPasswordResetsFormState>({
+      mode: "onSubmit",
+      defaultValues: {
+        newPassword: "",
+        newPasswordConfirm: "",
+        token,
+      },
+    });
+
+  async function onSubmit(data: IPasswordResetsFormState) {
+    await resetPassword(data);
+  }
+
+  const validationProps = useCallback(
+    (fieldName: keyof IPasswordResetsFormState) => {
+      const { invalid, error } = getFieldState(fieldName, formState);
+      return {
+        isInvalid: invalid,
+        error: error?.message,
+      };
+    },
+    [getFieldState, formState]
+  );
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="vertical-rhythm">
+      <Input
+        label={t("account.changePassword.newPassword")}
+        type="password"
+        {...validationProps("newPassword")}
+        {...register("newPassword", {
+          required: t("shared.requiredField", {
+            field: t("password_reset.newPassword.title"),
+          }),
+          minLength: {
+            value: 8,
+            message: t("shared.passwordLengthError"),
+          },
+        })}
+      />
+      <Input
+        label={t("account.changePassword.newPasswordConfirm")}
+        type="password"
+        {...validationProps("newPasswordConfirm")}
+        {...register("newPasswordConfirm", {
+          required: t("shared.requiredField", {
+            field: t("password_reset.newPasswordConfirm.title"),
+          }),
+          validate: (value) =>
+            value === watch("newPassword") ||
+            t("password_reset.newPasswordConfirmMismatch"),
+        })}
+      />
+      <div className="d-flex">
+        <AsyncButton
+          type="submit"
+          className="w-100 btn-lg"
+          disabled={!formState.isValid}
+          loading={formState.isSubmitted}
+        >
+          {t("password_reset.submit")}
+        </AsyncButton>
+      </div>
+    </form>
+  );
+}

--- a/src/app/password_resets/[token]/_components/PasswordResetForm.tsx
+++ b/src/app/password_resets/[token]/_components/PasswordResetForm.tsx
@@ -56,7 +56,7 @@ export default function PasswordResetForm({ token }: { token: string }) {
         {...validationProps("newPasswordConfirm")}
         {...register("newPasswordConfirm", {
           required: t("shared.requiredField", {
-            field: t("password_reset.newPasswordConfirm.title"),
+            field: t("account.changePassword.newPasswordConfirm"),
           }),
           validate: (value) =>
             value === watch("newPassword") ||
@@ -68,7 +68,7 @@ export default function PasswordResetForm({ token }: { token: string }) {
           type="submit"
           className="w-100 btn-lg"
           disabled={!formState.isValid}
-          loading={formState.isSubmitted}
+          loading={formState.isSubmitting}
         >
           {t("password_reset.submit")}
         </AsyncButton>

--- a/src/app/password_resets/[token]/layout.tsx
+++ b/src/app/password_resets/[token]/layout.tsx
@@ -1,7 +1,7 @@
 import LocaleSwitcher from "@/components/LocaleSwitcher";
 import Image from "next/image";
 import { Container } from "react-bootstrap";
-import icon from "../../../public/images/icon.svg";
+import icon from "@/../../public/images/icon.svg";
 import { getLocale, getTranslations } from "next-intl/server";
 import { getUser } from "@/lib/session";
 import { redirect } from "next/navigation";
@@ -36,13 +36,13 @@ export default async function Layout({
           <div className="text-center vertical-rhythm">
             <Image
               priority
-              src={icon.src}
+              src={icon}
               width="40"
               height="0"
               className="me-2 h-auto"
               alt={"Project Protocol logo"}
             />
-            <h2 className="mb-0">{t("login.loginTitle")}</h2>
+            <h2 className="mb-0">{t("password_reset.newPassword.title")}</h2>
           </div>
           {children}
         </div>

--- a/src/app/password_resets/[token]/page.tsx
+++ b/src/app/password_resets/[token]/page.tsx
@@ -1,10 +1,5 @@
 import PasswordResetForm from "./_components/PasswordResetForm";
 
 export default async function Page({ params }: { params: { token: string } }) {
-  // Get token from url param
-  // Pass to form
-  // On success, redirect to login
-  // On failure, show error
-
   return <PasswordResetForm token={params.token} />;
 }

--- a/src/app/password_resets/[token]/page.tsx
+++ b/src/app/password_resets/[token]/page.tsx
@@ -1,0 +1,10 @@
+import PasswordResetForm from "./_components/PasswordResetForm";
+
+export default async function Page({ params }: { params: { token: string } }) {
+  // Get token from url param
+  // Pass to form
+  // On success, redirect to login
+  // On failure, show error
+
+  return <PasswordResetForm token={params.token} />;
+}

--- a/src/components/login/ForgotPasswordForm.tsx
+++ b/src/components/login/ForgotPasswordForm.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import { useFormState } from "react-dom";
 import AsyncButton from "../AsyncButton";
 import { getErrorState } from "@/lib/forms";
-import { resetPassword } from "@/lib/actions/account";
+import { requestPasswordReset } from "@/lib/actions/account";
 
 const initialState = {
   error: undefined,
@@ -14,7 +14,7 @@ const initialState = {
 
 export default function ForgotPasswordForm() {
   const t = useTranslations();
-  const [state, formAction] = useFormState(resetPassword, initialState);
+  const [state, formAction] = useFormState(requestPasswordReset, initialState);
 
   return (
     <div className="d-block p-4">

--- a/src/components/notifications/DismissableToast.tsx
+++ b/src/components/notifications/DismissableToast.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { FlashMessage } from "@/lib/flash-messages";
+import { useTranslations } from "next-intl";
+import toast from "react-hot-toast";
+
+export default function DismissableToast({
+  flashMessage,
+}: {
+  flashMessage: FlashMessage;
+}) {
+  const t = useTranslations();
+  const { message, id } = flashMessage;
+  return (
+    <span>
+      {message}{" "}
+      <a className="text-white" role="button" onClick={() => toast.dismiss(id)}>
+        {t("shared.dismiss")}
+      </a>
+    </span>
+  );
+}

--- a/src/components/notifications/FlashMessages.tsx
+++ b/src/components/notifications/FlashMessages.tsx
@@ -3,6 +3,7 @@
 import { FlashMessage } from "@/lib/flash-messages";
 import { useEffect } from "react";
 import toast from "react-hot-toast";
+import DismissableToast from "./DismissableToast";
 
 export default function FlashMessages({
   messages,
@@ -11,10 +12,30 @@ export default function FlashMessages({
 }) {
   useEffect(() => {
     const toastFn = { success: toast.success, error: toast.error };
-    messages.forEach((message) => {
-      toastFn[message.type](message.message, { id: message.id });
+    messages.forEach((toastProps) => {
+      const { message, type, id, template, ...options }: FlashMessage =
+        toastProps;
+
+      const duration = template === "dismissable" ? Infinity : 4000;
+
+      toastFn[type](() => getTemplate(toastProps), {
+        id,
+        duration,
+        ...options,
+      });
     });
   });
 
   return null;
+}
+
+function getTemplate(flashMessage: FlashMessage) {
+  const { template } = flashMessage;
+  switch (template) {
+    case "dismissable":
+      return <DismissableToast flashMessage={flashMessage} />;
+
+    default:
+      return flashMessage.message;
+  }
 }

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -70,11 +70,14 @@ export interface IPasswordResetsFormState {
   token: string;
 }
 
+type ResetPasswordResponse = {
+  error?: MessageKeys<IntlMessages, "password_reset">;
+};
 export async function resetPassword({
   newPassword,
   newPasswordConfirm,
   token,
-}: IPasswordResetsFormState) {
+}: IPasswordResetsFormState): Promise<ResetPasswordResponse> {
   const t = await getTranslations();
   let messageKey;
 
@@ -85,21 +88,15 @@ export async function resetPassword({
     }),
   });
 
-  const { message, error } = await response.json();
-
+  const body = await response.json();
+  let error;
   if (!response.ok) {
-    if (error) {
-      messageKey = `password_reset.${error}`;
-    } else {
-      messageKey = "shared.genericError";
-    }
-    flashError(t(messageKey as MessageKeys<IntlMessages, "password_reset">));
-  } else {
-    messageKey = `password_reset.${message}`;
-    flashSuccess(t(messageKey as MessageKeys<IntlMessages, "password_reset">));
+    error = body?.error
+      ? `password_reset.${body.error}`
+      : "shared.genericError";
   }
 
-  redirect("/");
+  return { error } as ResetPasswordResponse;
 }
 
 export async function changePassword(prevState: any, formData: FormData) {

--- a/src/lib/flash-messages.ts
+++ b/src/lib/flash-messages.ts
@@ -5,7 +5,8 @@ export type FlashMessage = {
   id?: string;
   message: string;
   type: "success" | "error";
-  dismissable?: boolean;
+  template?: string;
+  opts?: any;
 };
 
 /**
@@ -27,8 +28,8 @@ export function flashError(txt: string) {
   flash({ message: txt, type: "error" });
 }
 
-export function flashSuccess(txt: string) {
-  flash({ message: txt, type: "success" });
+export function flashSuccess(txt: string, opts: any = {}) {
+  flash({ message: txt, type: "success", ...opts });
 }
 
 /**

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -96,6 +96,8 @@
     },
     "error": {
       "homeLink": "Main page",
+      "notFound": "Not Found",
+      "notFoundMessage": "Sorry, the page you are looking for does not exist.",
       "pageTitle": "Oops!"
     },
     "explore": "Explore Project Protocol",
@@ -322,7 +324,6 @@
     "genericError": "Something went wrong, please try again",
     "learnMore": "Learn more",
     "noResults": "No results found. Please try a different search.",
-    "notFound": "Not Found",
     "OK": "OK",
     "optional": "(optional)",
     "orLogIn": "or log in",

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -96,6 +96,8 @@
     },
     "error": {
       "homeLink": "Inicio",
+      "notFound": "No Encontrado",
+      "notFoundMessage": "Lo sentimos, la página que estás buscando no existe.",
       "pageTitle": "¡Ups!"
     },
     "explore": "Explorar Project Protocol",
@@ -300,7 +302,6 @@
     "genericError": "Ha ocurrido un error",
     "learnMore": "Aprende más",
     "noResults": "No se han encontrado resultados. Por favor intenta una búsqueda diferente.",
-    "notFound": "No Encontrado",
     "OK": "OK",
     "optional": "(opcional)",
     "orLogIn": "o inicia sesión",


### PR DESCRIPTION
## 🛠️ Changes
* Add forgot password UI to login pages.
* Add `password_resets/<token>` page and form to submit new password along with reset token
* Add pattern for flash message templates

## 🧪 Testing
Requires account on staging with an email you have access to.

1. Go to login and click "Forgot password"
2. Enter account email
3. Copy the link from the "RESET PASSWORD" button, and paste the path into the preview url, e.g.
```
<preview domain>/password_resets/abf14f6d-454d-4c1f-8a60-93eeddcc8f85?original_location=/
```
4. Try invalid password inputs on form (too short, mismatched passwords), check that form errors make sense and prevent submit while invalid.
6. Submit a valid password and matching confirmation.
7. Form should redirect to home with a success message.

**Alternatively:**
Test locally (probably simpler):
1. Pull this branch and run it.
2. API:
    - Set FRONTEND_HOST to http://localhost:3001 in `.env`
    - Restart server `docker compose restart web`. 
3. Test the "forgot password" flow on local client http://localhost:3001 -- Emails will be sent to mailcatcher UI (http://localhost:1080), where you can click on them to initiate the password reset flow as normal.
