### PR TITLE
Global loading bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-intersection-observer": "^9.10.3",
     "sass": "^1.77.5",
     "sharp": "^0.33.4",
+    "topbar": "^3.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       sharp:
         specifier: ^0.33.4
         version: 0.33.4
+      topbar:
+        specifier: ^3.0.0
+        version: 3.0.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1834,6 +1837,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  topbar@3.0.0:
+    resolution: {integrity: sha512-mhczD7KfYi1anfoMPKRdl0wPSWiYc0YOK4KyycYs3EaNT15pVVNDG5CtfgZcEBWIPJEdfR7r8K4hTXDD2ECBVQ==}
+
   ts-api-utils@1.3.0:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
@@ -2797,8 +2803,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -2816,13 +2822,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -2833,18 +2839,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -2854,7 +2860,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -3896,6 +3902,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  topbar@3.0.0: {}
 
   ts-api-utils@1.3.0(typescript@5.4.5):
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,12 @@ import { getLocale, getMessages } from "next-intl/server";
 import AuthProvider from "@/components/AuthProvider";
 import { getUser } from "@/lib/session";
 import NotificationArea from "@/components/notifications/NotificationArea";
+import dynamic from "next/dynamic";
+
+const ProgressBarWrapperNoSSR = dynamic(
+  () => import("@/components/GlobalProgressBar"),
+  { ssr: false }
+);
 
 const font = Source_Sans_3({ subsets: ["latin"] });
 
@@ -30,6 +36,7 @@ export default async function RootLayout({
           font.className + " w-100 min-vh-100 p-0 bg-light overflow-y-scroll"
         }
       >
+        <ProgressBarWrapperNoSSR />
         <NextIntlClientProvider messages={messages}>
           <NotificationArea />
           <AuthProvider user={user}>{children}</AuthProvider>

--- a/src/components/GlobalProgressBar.tsx
+++ b/src/components/GlobalProgressBar.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+/**
+ * GlobalProgressBar
+ * Adapted from https://github.com/TheSGJ/nextjs-toploader/blob/master/src/index.tsx
+ * @description Adds gobal event listeners to show and hide the topbar progress indicator when navigating between pages.
+ * @returns {null}
+ */
+import { useEffect } from "react";
+import topbar from "topbar";
+
+topbar.config({
+  barColors: {
+    "0": "#f06748",
+    ".3": "#ffc775",
+    "1.0": "#ffc775",
+  },
+  shadowBlur: 0,
+});
+
+const THRESHOLD = 200; // Only show if request takes longer than 200ms
+export default function GlobalProgressBar() {
+  const toAbsoluteURL = (url: string): string => {
+    return new URL(url, window.location.href).href;
+  };
+
+  useEffect((): ReturnType<React.EffectCallback> => {
+    const isHashAnchor = (currentUrl: string, newUrl: string): boolean => {
+      const current = new URL(toAbsoluteURL(currentUrl));
+      const next = new URL(toAbsoluteURL(newUrl));
+      return current.href.split("#")[0] === next.href.split("#")[0];
+    };
+
+    const isSameHostName = (currentUrl: string, newUrl: string): boolean => {
+      const current = new URL(toAbsoluteURL(currentUrl));
+      const next = new URL(toAbsoluteURL(newUrl));
+      return (
+        current.hostname.replace(/^www\./, "") ===
+        next.hostname.replace(/^www\./, "")
+      );
+    };
+
+    /**
+     * Check if the Current Url is same as New Url
+     * @param currentUrl {string}
+     * @param newUrl {string}
+     * @returns {boolean}
+     */
+    function isAnchorOfCurrentUrl(currentUrl: string, newUrl: string): boolean {
+      const currentUrlObj = new URL(currentUrl);
+      const newUrlObj = new URL(newUrl);
+      // Compare hostname, pathname, and search parameters
+      if (
+        currentUrlObj.hostname === newUrlObj.hostname &&
+        currentUrlObj.pathname === newUrlObj.pathname &&
+        currentUrlObj.search === newUrlObj.search
+      ) {
+        // Check if the new URL is just an anchor of the current URL page
+        const currentHash = currentUrlObj.hash;
+        const newHash = newUrlObj.hash;
+        return (
+          currentHash !== newHash &&
+          currentUrlObj.href.replace(currentHash, "") ===
+            newUrlObj.href.replace(newHash, "")
+        );
+      }
+      return false;
+    }
+
+    /**
+     * Find the closest anchor to trigger
+     * @param element {HTMLElement | null}
+     * @returns element {Element}
+     */
+    function findClosestAnchor(
+      element: HTMLElement | null
+    ): HTMLAnchorElement | null {
+      while (element && element.tagName.toLowerCase() !== "a") {
+        element = element.parentElement;
+      }
+      return element as HTMLAnchorElement;
+    }
+
+    /**
+     *
+     * @param event {MouseEvent}
+     * @returns {void}
+     */
+    function handleClick(event: MouseEvent): void {
+      try {
+        const target = event.target as HTMLElement;
+        const anchor = findClosestAnchor(target);
+        const newUrl = anchor?.href;
+        if (newUrl) {
+          const currentUrl = window.location.href;
+          // const newUrl = (anchor as HTMLAnchorElement).href;
+          const isExternalLink =
+            (anchor as HTMLAnchorElement).target === "_blank";
+
+          // Check for Special Schemes
+          const isSpecialScheme = [
+            "tel:",
+            "mailto:",
+            "sms:",
+            "blob:",
+            "download:",
+          ].some((scheme) => newUrl.startsWith(scheme));
+
+          const isAnchor: boolean = isAnchorOfCurrentUrl(currentUrl, newUrl);
+          const notSameHost = !isSameHostName(
+            window.location.href,
+            anchor.href
+          );
+          if (notSameHost) {
+            return;
+          }
+          if (
+            newUrl === currentUrl ||
+            isAnchor ||
+            isExternalLink ||
+            isSpecialScheme ||
+            event.ctrlKey ||
+            event.metaKey ||
+            event.shiftKey ||
+            event.altKey ||
+            isHashAnchor(window.location.href, anchor.href) ||
+            !toAbsoluteURL(anchor.href).startsWith("http")
+          ) {
+          } else {
+            topbar.show();
+          }
+        }
+      } catch (err) {
+        topbar.hide();
+      }
+    }
+
+    /**
+     * Complete TopLoader Progress on adding new entry to history stack
+     * @param {History}
+     * @returns {void}
+     */
+    ((history: History): void => {
+      const pushState = history.pushState;
+      history.pushState = (...args) => {
+        topbar.hide();
+        return pushState.apply(history, args);
+      };
+    })((window as Window).history);
+
+    /**
+     * Complete TopLoader Progress on replacing current entry of history stack
+     * @param {History}
+     * @returns {void}
+     */
+    ((history: History): void => {
+      const replaceState = history.replaceState;
+      history.replaceState = (...args) => {
+        topbar.hide();
+        return replaceState.apply(history, args);
+      };
+    })((window as Window).history);
+
+    function handlePageHide(): void {
+      topbar.hide();
+    }
+
+    /**
+     * Handle Browser Back and Forth Navigation
+     * @returns {void}
+     */
+    function handleBackAndForth(): void {
+      topbar.hide();
+    }
+
+    // Add the global click event listener
+    window.addEventListener("popstate", handleBackAndForth);
+    document.addEventListener("click", handleClick);
+    window.addEventListener("pagehide", handlePageHide);
+
+    // Clean up the global click event listener when the component is unmounted
+    return (): void => {
+      document.removeEventListener("click", handleClick);
+      window.removeEventListener("pagehide", handlePageHide);
+      window.removeEventListener("popstate", handleBackAndForth);
+    };
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## 🛠️ Changes
* Adapts a pattern that adds global click listeners on anchor elements.
* Calls topbar.show() on click if the link matches typical page navigation criteria.
* Listens to window.history events to trigger topbar.hide() (these fire on page load completion).
* Wraps component in a dynamic import which prevents server-side rendering of the client, ensuring that the `window` object is available.

## 🧪 Testing
Click around the site and see the progress bar when pages are loading. It wont show if the page is cached.

## Future
There's widespread complaint about Nextjs removing router events, which would make this doable in probably 10 lines of code. Hopefully they listen to the community and add them back, at which point we can vastly simplify this.
