### PR TITLE
Add agent page

### DIFF
--- a/src/app/(main-layout)/agents/new/_components/AddAgentForm.tsx
+++ b/src/app/(main-layout)/agents/new/_components/AddAgentForm.tsx
@@ -4,55 +4,64 @@ import SearchResult from "@/components/search/SearchResult";
 import Office from "@/types/Office";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
-import { Button, FloatingLabel, Form } from "react-bootstrap";
-import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import Button from "react-bootstrap/Button";
+import {
+  Controller,
+  FieldValues,
+  SubmitHandler,
+  useForm,
+} from "react-hook-form";
 import SelectOfficeModal from "./SelectOfficeModal";
 import Input from "@/components/Input";
-
-interface IAddAnAgentForm {
-  firstName?: string;
-  lastName: string;
-  office: Office;
-}
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createAgent } from "@/lib/actions/agent";
+import toast from "react-hot-toast";
+import { useRouter } from "next/navigation";
+import AsyncButton from "@/components/AsyncButton";
 
 export default function AddAgentForm() {
   const [showModal, setShowModal] = useState(false);
+  const [selectedOffice, setSelectedOffice] = useState<Office>();
+  const [loading, setLoading] = useState(false);
   const tAgent = useTranslations("agent");
   const tShared = useTranslations("shared");
+  const router = useRouter();
+
+  const AddAgentSchema = z.object({
+    firstName: z.string().optional(),
+    lastName: z.string().min(1, { message: tAgent("form.lastNameRequired") }),
+    officeId: z
+      .string({ message: tAgent("form.selectOfficeRequired") })
+      .min(1, { message: tAgent("form.selectOfficeRequired") }),
+  });
+
+  type AddAgentSchema = z.infer<typeof AddAgentSchema>;
 
   const {
     register,
     handleSubmit,
     formState: { errors },
-    watch,
     control,
-  } = useForm<IAddAnAgentForm>({
+  } = useForm<AddAgentSchema>({
     mode: "onSubmit",
-    defaultValues: { firstName: "", lastName: "", office: undefined },
+    resolver: zodResolver(AddAgentSchema),
   });
-
-  const office = watch("office");
 
   const handleClose = () => {
     setShowModal(false);
   };
 
-  const onSubmit: SubmitHandler<IAddAnAgentForm> = async ({
-    office,
-    ...params
-  }: IAddAnAgentForm) => {
-    console.log(office, params);
-    //  const newAgent = await ApiAgent.create({
-    //    ...params,
-    //    officeId: office.id,
-    //  });
-
-    //  if (newAgent) {
-    //    toast.success(t("successToast"));
-    //    navigate(`/agents/${newAgent.agent.id}`, { replace: true });
-    //  } else {
-    //    toast.error(t("genericError"));
-    //  }
+  const onSubmit = async (params: AddAgentSchema) => {
+    setLoading(true);
+    const { agent } = await createAgent(params);
+    if (agent) {
+      toast.success(tAgent("successToast"));
+      router.replace(`/agents/${agent.id}`);
+    } else {
+      setLoading(false);
+      toast.error(tShared("genericError"));
+    }
   };
 
   return (
@@ -77,14 +86,14 @@ export default function AddAgentForm() {
         />
         <div className="mb-3">
           <h3 className="mb-0"> {tAgent("form.office")}</h3>
-          {!!errors?.office && (
-            <small className="text-danger">{errors?.office?.message}</small>
+          {!!errors?.officeId && (
+            <small className="text-danger">{errors?.officeId?.message}</small>
           )}
         </div>
         <div className="p-3 mb-3">
-          {office ? (
+          {selectedOffice ? (
             <div>
-              <SearchResult result={office} />
+              <SearchResult result={selectedOffice} />
               <div className="text-center">
                 <a
                   className="link-dark"
@@ -108,26 +117,29 @@ export default function AddAgentForm() {
           )}
         </div>
         <div className="mt-5">
-          <Button
+          <AsyncButton
             size="lg"
             variant="primary"
             disabled={!errors}
             type="submit"
-            className="w-100 w-md-auto mx-auto"
+            className="w-100"
+            loading={loading}
           >
             {tAgent("form.createListing")}
-          </Button>
+          </AsyncButton>
         </div>
       </form>
       <Controller
-        name="office"
+        name="officeId"
         control={control}
-        rules={{ required: tAgent("form.selectOfficeRequired") }}
         render={({ field }) => (
           <SelectOfficeModal
             show={showModal}
             close={handleClose}
-            selectOffice={field.onChange}
+            selectOffice={(office: Office) => {
+              setSelectedOffice(office);
+              field.onChange(String(office.id));
+            }}
           />
         )}
       />

--- a/src/app/(main-layout)/agents/new/_components/AddAgentForm.tsx
+++ b/src/app/(main-layout)/agents/new/_components/AddAgentForm.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import SearchResult from "@/components/search/SearchResult";
+import Office from "@/types/Office";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { Button, FloatingLabel, Form } from "react-bootstrap";
+import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import SelectOfficeModal from "./SelectOfficeModal";
+import Input from "@/components/Input";
+
+interface IAddAnAgentForm {
+  firstName?: string;
+  lastName: string;
+  office: Office;
+}
+
+export default function AddAgentForm() {
+  const [showModal, setShowModal] = useState(false);
+  const tAgent = useTranslations("agent");
+  const tShared = useTranslations("shared");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+    control,
+  } = useForm<IAddAnAgentForm>({
+    mode: "onSubmit",
+    defaultValues: { firstName: "", lastName: "", office: undefined },
+  });
+
+  const office = watch("office");
+
+  const handleClose = () => {
+    setShowModal(false);
+  };
+
+  const onSubmit: SubmitHandler<IAddAnAgentForm> = async ({
+    office,
+    ...params
+  }: IAddAnAgentForm) => {
+    console.log(office, params);
+    //  const newAgent = await ApiAgent.create({
+    //    ...params,
+    //    officeId: office.id,
+    //  });
+
+    //  if (newAgent) {
+    //    toast.success(t("successToast"));
+    //    navigate(`/agents/${newAgent.agent.id}`, { replace: true });
+    //  } else {
+    //    toast.error(t("genericError"));
+    //  }
+  };
+
+  return (
+    <>
+      <h3 className="mb-3">{tAgent("form.title")}</h3>
+      <form onSubmit={handleSubmit(onSubmit)} className="vertical-rhythm">
+        <Input
+          label={`${tAgent("form.firstName")} ${tShared("optional")}`}
+          className="mb-3 w-100"
+          type="text"
+          {...register("firstName")}
+        />
+        <Input
+          type="text"
+          label={tAgent("form.lastName")}
+          className="mb-3 w-100"
+          isInvalid={!!errors?.lastName}
+          error={errors?.lastName?.message}
+          {...register("lastName", {
+            required: tAgent("form.lastNameRequired"),
+          })}
+        />
+        <div className="mb-3">
+          <h3 className="mb-0"> {tAgent("form.office")}</h3>
+          {!!errors?.office && (
+            <small className="text-danger">{errors?.office?.message}</small>
+          )}
+        </div>
+        <div className="p-3 mb-3">
+          {office ? (
+            <div>
+              <SearchResult result={office} />
+              <div className="text-center">
+                <a
+                  className="link-dark"
+                  role="button"
+                  onClick={() => setShowModal(true)}
+                >
+                  {tAgent("form.edit")}
+                </a>
+              </div>
+            </div>
+          ) : (
+            <div className="text-center">
+              <a
+                className="link-dark"
+                role="button"
+                onClick={() => setShowModal(true)}
+              >
+                {tAgent("form.selectOffice")}
+              </a>
+            </div>
+          )}
+        </div>
+        <div className="mt-5">
+          <Button
+            size="lg"
+            variant="primary"
+            disabled={!errors}
+            type="submit"
+            className="w-100 w-md-auto mx-auto"
+          >
+            {tAgent("form.createListing")}
+          </Button>
+        </div>
+      </form>
+      <Controller
+        name="office"
+        control={control}
+        rules={{ required: tAgent("form.selectOfficeRequired") }}
+        render={({ field }) => (
+          <SelectOfficeModal
+            show={showModal}
+            close={handleClose}
+            selectOffice={field.onChange}
+          />
+        )}
+      />
+    </>
+  );
+}

--- a/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
+++ b/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
@@ -71,6 +71,7 @@ export default function SelectOfficeModal({
         />
         <SearchResultsInfo meta={initialData.meta} />
         <Paginator<Office>
+          animated
           meta={initialData.meta}
           data={initialData.data}
           keyGenerator={(o) => `agent-office-select-${o.id}`}

--- a/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
+++ b/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import PopUp from "@/components/PopUp";
+import SearchBar from "@/components/SearchBar";
+import Office from "@/types/Office";
+import { debounce } from "lodash";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+interface ISelectOfficeModal {
+  show: boolean;
+  close: () => void;
+  selectOffice: (o: Office) => void;
+}
+
+export default function SelectOfficeModal({
+  close,
+  show,
+  selectOffice,
+}: ISelectOfficeModal) {
+  const [searchText, setSearchText] = useState("");
+  const t = useTranslations("agent");
+  const onChange = debounce(setSearchText, 500);
+
+  return (
+    <PopUp
+      title={t("selectOffice")}
+      closeButton
+      show={show}
+      size={undefined}
+      scrollable
+      centered={false}
+      bodyClass="p-3"
+      onHide={() => {
+        setSearchText("");
+        close();
+      }}
+    >
+      <div className="pt-3" style={{ minHeight: "40vh" }}>
+        <SearchBar
+          id="search"
+          name="search"
+          aria-label={t("searchOffices")}
+          size="lg"
+          placeholder={t("searchOffices")}
+          type="text"
+          defaultValue={searchText}
+          onChange={(e) => {
+            onChange(e.target.value);
+          }}
+          autoFocus
+        />
+      </div>
+    </PopUp>
+  );
+}

--- a/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
+++ b/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
@@ -16,7 +16,7 @@ import { useEffect, useState } from "react";
 interface ISelectOfficeModal {
   show: boolean;
   close: () => void;
-  selectOffice: (o: Office) => void;
+  selectOffice: (office: Office) => void;
 }
 
 export default function SelectOfficeModal({
@@ -48,6 +48,7 @@ export default function SelectOfficeModal({
       scrollable
       centered={false}
       bodyClass="p-md-4 overflow-y-scroll"
+      style={{ minHeight: "600px" }}
       onHide={() => {
         setSearchText("");
         close();

--- a/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
+++ b/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
@@ -1,11 +1,17 @@
 "use client";
 
+import ListItem from "@/components/ListItem";
+import Paginator from "@/components/Paginator";
 import PopUp from "@/components/PopUp";
+import SearchResultOffice from "@/components/search/SearchResultOffice";
+import SearchResultsInfo from "@/components/search/SearchResultsInfo";
 import SearchBar from "@/components/SearchBar";
+import { listOffices } from "@/lib/actions/office";
 import Office from "@/types/Office";
+import { SearchData } from "@/types/Search";
 import { debounce } from "lodash";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface ISelectOfficeModal {
   show: boolean;
@@ -21,22 +27,33 @@ export default function SelectOfficeModal({
   const [searchText, setSearchText] = useState("");
   const t = useTranslations("agent");
   const onChange = debounce(setSearchText, 500);
+  const [initialData, setInitialData] = useState<SearchData<Office>>({
+    data: [],
+    meta: { page: 0, totalPages: 0, total: 0 },
+  });
+
+  useEffect(() => {
+    if (!show) return;
+    listOffices({ search: searchText, page: 0 }).then((data) => {
+      setInitialData(data);
+    });
+  }, [searchText, show]);
 
   return (
     <PopUp
       title={t("selectOffice")}
       closeButton
       show={show}
-      size={undefined}
+      size="lg"
       scrollable
       centered={false}
-      bodyClass="p-3"
+      bodyClass="p-md-4 overflow-y-scroll"
       onHide={() => {
         setSearchText("");
         close();
       }}
     >
-      <div className="pt-3" style={{ minHeight: "40vh" }}>
+      <div className="pt-3 vertical-rhythm" style={{ minHeight: "40vh" }}>
         <SearchBar
           id="search"
           name="search"
@@ -48,7 +65,29 @@ export default function SelectOfficeModal({
           onChange={(e) => {
             onChange(e.target.value);
           }}
+          onClear={() => onChange("")}
           autoFocus
+        />
+        <SearchResultsInfo meta={initialData.meta} />
+        <Paginator<Office>
+          meta={initialData.meta}
+          data={initialData.data}
+          keyGenerator={(o) => `agent-office-select-${o.id}`}
+          getData={async (page) =>
+            await listOffices({ search: searchText, page })
+          }
+          ItemComponent={({ item, page, index }) => (
+            <ListItem
+              role="button"
+              onClick={() => {
+                selectOffice(item);
+                close();
+              }}
+              body
+            >
+              <SearchResultOffice office={item} />
+            </ListItem>
+          )}
         />
       </div>
     </PopUp>

--- a/src/app/(main-layout)/agents/new/page.tsx
+++ b/src/app/(main-layout)/agents/new/page.tsx
@@ -1,0 +1,37 @@
+import PageHeader from "@/components/PageHeader";
+import { getTranslations } from "next-intl/server";
+import officerIcon from "@/../public/images/officer-icon.svg";
+import Image from "next/image";
+import { getUser } from "@/lib/session";
+import { redirect } from "next/navigation";
+import AddAgentForm from "./_components/AddAgentForm";
+
+export default async function Page() {
+  const t = await getTranslations();
+  const user = await getUser();
+
+  if (!user) {
+    redirect("/");
+  }
+
+  return (
+    <div>
+      <PageHeader title={t("agent.addAgent")} showBack />
+      <div className="vertical-rhythm">
+        <div
+          className="d-flex flex-row m-auto justify-content-center align-items-center bg-white rounded-circle my-4"
+          style={{ width: 80, height: 80 }}
+        >
+          <Image
+            width={40}
+            height={40}
+            src={officerIcon.src}
+            alt={t("agent.officerIconAlt")}
+          />
+        </div>
+        <p className="mb-5">{t("agent.addAgentDescription")}</p>
+        <AddAgentForm />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main-layout)/rate-my-po/_components/AddAgentCard.tsx
+++ b/src/app/(main-layout)/rate-my-po/_components/AddAgentCard.tsx
@@ -1,7 +1,6 @@
 import Card from "react-bootstrap/Card";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { getUser } from "@/lib/session";
 import { useAuth } from "@/components/AuthProvider";
 
 interface IAddAgentCard {

--- a/src/app/(main-layout)/rate-my-po/_components/ResultsList.tsx
+++ b/src/app/(main-layout)/rate-my-po/_components/ResultsList.tsx
@@ -5,7 +5,6 @@ import SearchResult from "@/components/search/SearchResult";
 import Paginator from "@/components/Paginator";
 import Agent from "@/types/Agent";
 import Office from "@/types/Office";
-import { LazyMotion, domAnimation, m } from "framer-motion";
 import AddAgentCard from "./AddAgentCard";
 import { useTranslations } from "next-intl";
 
@@ -18,7 +17,7 @@ type ResultsListProps = {
 export default function ResultsList({
   initialData,
   getMore,
-  searchText,
+  searchText = "",
 }: ResultsListProps) {
   const t = useTranslations();
   return (
@@ -30,43 +29,18 @@ export default function ResultsList({
             })
           : t("rate_my_po.mostRecent")}
       </p>
-      <LazyMotion features={domAnimation}>
-        <Paginator<Agent | Office>
-          data={initialData.data}
-          meta={initialData.meta}
-          getData={getMore}
-          keyGenerator={(item) =>
-            `search-result-${searchText}-${item.type}-${item.id}`
-          }
-          ItemComponent={({ item, index }) => (
-            <m.div
-              animate={{ opacity: 1, y: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              transition={{ delay: index * 0.05, ease: "easeOut" }}
-            >
-              <SearchResult result={item} />
-            </m.div>
-          )}
-          ListEndComponent={({ index }) => (
-            <m.div
-              animate={{ opacity: 1, y: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              transition={{ delay: index * 0.05, ease: "easeOut" }}
-            >
-              <AddAgentCard />
-            </m.div>
-          )}
-        />
-        {initialData.meta.total === 0 && (
-          <m.div
-            animate={{ opacity: 1, y: 0 }}
-            initial={{ opacity: 0, y: 30 }}
-            transition={{ ease: "easeOut" }}
-          >
-            <AddAgentCard />
-          </m.div>
-        )}
-      </LazyMotion>
+      <Paginator<Agent | Office>
+        animated
+        data={initialData.data}
+        meta={initialData.meta}
+        getData={getMore}
+        keyGenerator={(item) =>
+          `search-result-${String(searchText)}-${item.type}-${item.id}`
+        }
+        ItemComponent={({ item }) => <SearchResult result={item} />}
+        ListEndComponent={AddAgentCard}
+      />
+      {initialData.meta.total === 0 && <AddAgentCard />}
     </>
   );
 }

--- a/src/app/(main-layout)/resources/[id]/_components/ResourceCommentsList.tsx
+++ b/src/app/(main-layout)/resources/[id]/_components/ResourceCommentsList.tsx
@@ -3,40 +3,28 @@
 import Paginator from "@/components/Paginator";
 import Comment from "@/types/Comment";
 import { Page } from "@/types/Search";
-import { domAnimation, LazyMotion, m } from "framer-motion";
 import { listComments } from "@/lib/actions/resource";
 import ResourceComment from "./ResourceComment";
 
 export default function ResourceCommentsList({
   resourceId,
-  initialData,
+  initialData = { data: [], meta: { total: 0, totalPages: 0, page: 0 } },
 }: {
   resourceId: number;
   initialData: Page<Comment>;
 }) {
   return (
     <div className="vertical-rhythm">
-      <LazyMotion features={domAnimation}>
-        {initialData && (
-          <Paginator<Comment>
-            data={initialData.data}
-            meta={initialData.meta}
-            getData={async (page) => await listComments(resourceId, page)}
-            keyGenerator={(item, page) =>
-              `comment-${resourceId}-${page}-${item.createdAt}`
-            }
-            ItemComponent={({ item, index }) => (
-              <m.div
-                animate={{ opacity: 1, y: 0 }}
-                initial={{ opacity: 0, y: 30 }}
-                transition={{ delay: index * 0.05, ease: "easeOut" }}
-              >
-                <ResourceComment comment={item} />
-              </m.div>
-            )}
-          />
-        )}
-      </LazyMotion>
+      <Paginator<Comment>
+        animated
+        data={initialData.data}
+        meta={initialData.meta}
+        getData={async (page) => await listComments(resourceId, page)}
+        keyGenerator={(item, page) =>
+          `comment-${resourceId}-${page}-${item.createdAt}`
+        }
+        ItemComponent={({ item }) => <ResourceComment comment={item} />}
+      />
     </div>
   );
 }

--- a/src/app/(main-layout)/resources/[id]/_components/UnauthorizedCommentArea.tsx
+++ b/src/app/(main-layout)/resources/[id]/_components/UnauthorizedCommentArea.tsx
@@ -4,7 +4,7 @@ import { Button } from "react-bootstrap";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 
-export default async function UnauthorizedCommentArea() {
+export default function UnauthorizedCommentArea() {
   const t = useTranslations();
   const router = useRouter();
   return (

--- a/src/app/(main-layout)/resources/_components/ResourcesSearchResults.tsx
+++ b/src/app/(main-layout)/resources/_components/ResourcesSearchResults.tsx
@@ -4,7 +4,6 @@ import Paginator from "@/components/Paginator";
 import Resource, { ResourceSearchParams } from "@/types/Resource";
 import { SearchData } from "@/types/Search";
 import ResourceCard from "./ResourceCard";
-import { domAnimation, LazyMotion, m } from "framer-motion";
 import { searchResources } from "@/lib/actions/resource";
 
 export default function ResourceSearchResults({
@@ -18,27 +17,18 @@ export default function ResourceSearchResults({
 
   return (
     <div className="vertical-rhythm">
-      <LazyMotion features={domAnimation}>
-        <Paginator<Resource>
-          data={initialData.data}
-          meta={initialData.meta}
-          getData={async (page) =>
-            await searchResources({ page: String(page), search: searchText })
-          }
-          keyGenerator={(item, page) =>
-            `search-result-${searchText}-${item.type}-${page}-${item.id}`
-          }
-          ItemComponent={({ item, index }) => (
-            <m.div
-              animate={{ opacity: 1, y: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              transition={{ delay: index * 0.05, ease: "easeOut" }}
-            >
-              <ResourceCard resource={item} />
-            </m.div>
-          )}
-        />
-      </LazyMotion>
+      <Paginator<Resource>
+        animated
+        data={initialData.data}
+        meta={initialData.meta}
+        getData={async (page) =>
+          await searchResources({ page: String(page), search: searchText })
+        }
+        keyGenerator={(item, page) =>
+          `search-result-${searchText}-${item.type}-${page}-${item.id}`
+        }
+        ItemComponent={({ item }) => <ResourceCard resource={item} />}
+      />
     </div>
   );
 }

--- a/src/components/AnimatedList.tsx
+++ b/src/components/AnimatedList.tsx
@@ -2,6 +2,7 @@
 
 import { LazyMotion, domAnimation, m } from "framer-motion";
 import React from "react";
+import AnimatedItem from "./Paginator/AnimatedItem";
 
 export default function AnimatedList({
   children,
@@ -11,13 +12,9 @@ export default function AnimatedList({
   return (
     <LazyMotion features={domAnimation}>
       {React.Children.map(children, (child, index) => (
-        <m.div
-          animate={{ opacity: 1, y: 0 }}
-          initial={{ opacity: 0, y: 30 }}
-          transition={{ delay: index * 0.15, ease: "easeOut" }}
-        >
+        <AnimatedItem key={`animated-item-${index}`} index={index} animated>
           {child}
-        </m.div>
+        </AnimatedItem>
       ))}
     </LazyMotion>
   );

--- a/src/components/Paginator.tsx
+++ b/src/components/Paginator.tsx
@@ -26,7 +26,7 @@ export default function Paginator<T>({
 }: IPaginator<T>) {
   const [page, setPage] = useState(meta.page);
   const [totalPages, setTotalPages] = useState(meta.totalPages);
-  const [itemPages, setItemPages] = useState<T[][]>([data] || []);
+  const [itemPages, setItemPages] = useState<T[][]>(data ? [data] : []);
   const [pageLoading, setPageLoading] = useState(false);
 
   useEffect(() => {

--- a/src/components/Paginator/AnimatedItem.tsx
+++ b/src/components/Paginator/AnimatedItem.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { m } from "framer-motion";
+
+export default function AnimatedItem({
+  animated,
+  index,
+  children,
+}: {
+  animated?: boolean;
+  index: number;
+  children: React.ReactNode;
+}) {
+  if (animated) {
+    return (
+      <m.div
+        animate={{ opacity: 1, y: 0 }}
+        initial={{ opacity: 0, y: 30 }}
+        transition={{ delay: index * 0.15, ease: "easeOut" }}
+      >
+        {children}
+      </m.div>
+    );
+  } else {
+    return children;
+  }
+}

--- a/src/lib/actions/agent.ts
+++ b/src/lib/actions/agent.ts
@@ -6,8 +6,9 @@ import Api from "../api";
 import { flashError, flashSuccess } from "../flash-messages";
 import { revalidatePath } from "next/cache";
 import { IRateAgentFormState } from "@/app/(main-layout)/agents/[agentId]/_components/RateAgentForm/types";
-import { snakeCase } from "lodash";
+import { replace, snakeCase } from "lodash";
 import { snakeCaseKeys } from "../transformKeys";
+import { redirect } from "next/navigation";
 
 export default async function rateAgent(
   agentId: string,
@@ -35,4 +36,29 @@ export default async function rateAgent(
   );
 
   revalidatePath(`/agents/${agentId}`);
+}
+
+export async function createAgent({
+  firstName = "",
+  lastName,
+  officeId,
+}: {
+  firstName?: string;
+  lastName: string;
+  officeId: string;
+}) {
+  const t = await getTranslations();
+  const session = await getSession();
+  const agent = snakeCaseKeys({ firstName, lastName, officeId });
+  const response = await new Api(session?.apiToken).post(`/agents`, {
+    body: JSON.stringify({ agent }),
+  });
+
+  const data = await response.json();
+
+  if (response.ok) {
+    return data;
+  } else {
+    return false;
+  }
 }

--- a/src/lib/actions/office.ts
+++ b/src/lib/actions/office.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import Office from "@/types/Office";
+import Api from "../api";
+import { SearchData } from "@/types/Search";
+
+interface IListOfficesParams {
+  page: number;
+  search: string;
+}
+export async function listOffices({
+  page = 0,
+  search = "",
+}): Promise<SearchData<Office>> {
+  const url = `offices?page=${page}&search=${search}`;
+  const result = await new Api().get(url);
+  const data = await result.json();
+  return data;
+}

--- a/src/types/Office.ts
+++ b/src/types/Office.ts
@@ -1,10 +1,10 @@
 type Office = {
-  id: number
-  street: string
-  city: string
-  state: string
-  zip: string
-  type: string
-}
+  id: number;
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+  type: string;
+};
 
-export default Office
+export default Office;


### PR DESCRIPTION
## 🛠️ Changes
Adds the `agents/new` page for creating a new agent.
<img width="411" alt="image" src="https://github.com/user-attachments/assets/2131afc2-d0c3-4796-9b9f-5b869a5a00c7">
<img width="393" alt="image" src="https://github.com/user-attachments/assets/3fa9962e-0b48-48fa-80d4-5cd5f97b9ae3">

## 🧪 Testing
* Test error path submitting with empty required fields
* Test happy path with last name and selected office (first name optional)

### Future notes
I added tickets for allowing the user to specify or create the unit that the agent belongs to. We have this data table and associations in the back-end, but it has gone unused.