### PR TITLE
[PRO-371] Consolidate list animation (animated Paginator)

### DIFF
--- a/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
+++ b/src/app/(main-layout)/agents/new/_components/SelectOfficeModal.tsx
@@ -71,6 +71,7 @@ export default function SelectOfficeModal({
         />
         <SearchResultsInfo meta={initialData.meta} />
         <Paginator<Office>
+          animated
           meta={initialData.meta}
           data={initialData.data}
           keyGenerator={(o) => `agent-office-select-${o.id}`}

--- a/src/app/(main-layout)/rate-my-po/_components/ResultsList.tsx
+++ b/src/app/(main-layout)/rate-my-po/_components/ResultsList.tsx
@@ -5,7 +5,6 @@ import SearchResult from "@/components/search/SearchResult";
 import Paginator from "@/components/Paginator";
 import Agent from "@/types/Agent";
 import Office from "@/types/Office";
-import { LazyMotion, domAnimation, m } from "framer-motion";
 import AddAgentCard from "./AddAgentCard";
 import { useTranslations } from "next-intl";
 
@@ -18,7 +17,7 @@ type ResultsListProps = {
 export default function ResultsList({
   initialData,
   getMore,
-  searchText,
+  searchText = "",
 }: ResultsListProps) {
   const t = useTranslations();
   return (
@@ -30,43 +29,18 @@ export default function ResultsList({
             })
           : t("rate_my_po.mostRecent")}
       </p>
-      <LazyMotion features={domAnimation}>
-        <Paginator<Agent | Office>
-          data={initialData.data}
-          meta={initialData.meta}
-          getData={getMore}
-          keyGenerator={(item) =>
-            `search-result-${searchText}-${item.type}-${item.id}`
-          }
-          ItemComponent={({ item, index }) => (
-            <m.div
-              animate={{ opacity: 1, y: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              transition={{ delay: index * 0.05, ease: "easeOut" }}
-            >
-              <SearchResult result={item} />
-            </m.div>
-          )}
-          ListEndComponent={({ index }) => (
-            <m.div
-              animate={{ opacity: 1, y: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              transition={{ delay: index * 0.05, ease: "easeOut" }}
-            >
-              <AddAgentCard />
-            </m.div>
-          )}
-        />
-        {initialData.meta.total === 0 && (
-          <m.div
-            animate={{ opacity: 1, y: 0 }}
-            initial={{ opacity: 0, y: 30 }}
-            transition={{ ease: "easeOut" }}
-          >
-            <AddAgentCard />
-          </m.div>
-        )}
-      </LazyMotion>
+      <Paginator<Agent | Office>
+        animated
+        data={initialData.data}
+        meta={initialData.meta}
+        getData={getMore}
+        keyGenerator={(item) =>
+          `search-result-${String(searchText)}-${item.type}-${item.id}`
+        }
+        ItemComponent={({ item }) => <SearchResult result={item} />}
+        ListEndComponent={AddAgentCard}
+      />
+      {initialData.meta.total === 0 && <AddAgentCard />}
     </>
   );
 }

--- a/src/app/(main-layout)/resources/[id]/_components/ResourceCommentsList.tsx
+++ b/src/app/(main-layout)/resources/[id]/_components/ResourceCommentsList.tsx
@@ -3,40 +3,28 @@
 import Paginator from "@/components/Paginator";
 import Comment from "@/types/Comment";
 import { Page } from "@/types/Search";
-import { domAnimation, LazyMotion, m } from "framer-motion";
 import { listComments } from "@/lib/actions/resource";
 import ResourceComment from "./ResourceComment";
 
 export default function ResourceCommentsList({
   resourceId,
-  initialData,
+  initialData = { data: [], meta: { total: 0, totalPages: 0, page: 0 } },
 }: {
   resourceId: number;
   initialData: Page<Comment>;
 }) {
   return (
     <div className="vertical-rhythm">
-      <LazyMotion features={domAnimation}>
-        {initialData && (
-          <Paginator<Comment>
-            data={initialData.data}
-            meta={initialData.meta}
-            getData={async (page) => await listComments(resourceId, page)}
-            keyGenerator={(item, page) =>
-              `comment-${resourceId}-${page}-${item.createdAt}`
-            }
-            ItemComponent={({ item, index }) => (
-              <m.div
-                animate={{ opacity: 1, y: 0 }}
-                initial={{ opacity: 0, y: 30 }}
-                transition={{ delay: index * 0.05, ease: "easeOut" }}
-              >
-                <ResourceComment comment={item} />
-              </m.div>
-            )}
-          />
-        )}
-      </LazyMotion>
+      <Paginator<Comment>
+        animated
+        data={initialData.data}
+        meta={initialData.meta}
+        getData={async (page) => await listComments(resourceId, page)}
+        keyGenerator={(item, page) =>
+          `comment-${resourceId}-${page}-${item.createdAt}`
+        }
+        ItemComponent={({ item }) => <ResourceComment comment={item} />}
+      />
     </div>
   );
 }

--- a/src/app/(main-layout)/resources/_components/ResourcesSearchResults.tsx
+++ b/src/app/(main-layout)/resources/_components/ResourcesSearchResults.tsx
@@ -4,7 +4,6 @@ import Paginator from "@/components/Paginator";
 import Resource, { ResourceSearchParams } from "@/types/Resource";
 import { SearchData } from "@/types/Search";
 import ResourceCard from "./ResourceCard";
-import { domAnimation, LazyMotion, m } from "framer-motion";
 import { searchResources } from "@/lib/actions/resource";
 
 export default function ResourceSearchResults({
@@ -18,27 +17,18 @@ export default function ResourceSearchResults({
 
   return (
     <div className="vertical-rhythm">
-      <LazyMotion features={domAnimation}>
-        <Paginator<Resource>
-          data={initialData.data}
-          meta={initialData.meta}
-          getData={async (page) =>
-            await searchResources({ page: String(page), search: searchText })
-          }
-          keyGenerator={(item, page) =>
-            `search-result-${searchText}-${item.type}-${page}-${item.id}`
-          }
-          ItemComponent={({ item, index }) => (
-            <m.div
-              animate={{ opacity: 1, y: 0 }}
-              initial={{ opacity: 0, y: 30 }}
-              transition={{ delay: index * 0.05, ease: "easeOut" }}
-            >
-              <ResourceCard resource={item} />
-            </m.div>
-          )}
-        />
-      </LazyMotion>
+      <Paginator<Resource>
+        animated
+        data={initialData.data}
+        meta={initialData.meta}
+        getData={async (page) =>
+          await searchResources({ page: String(page), search: searchText })
+        }
+        keyGenerator={(item, page) =>
+          `search-result-${searchText}-${item.type}-${page}-${item.id}`
+        }
+        ItemComponent={({ item }) => <ResourceCard resource={item} />}
+      />
     </div>
   );
 }

--- a/src/components/AnimatedList.tsx
+++ b/src/components/AnimatedList.tsx
@@ -2,6 +2,7 @@
 
 import { LazyMotion, domAnimation, m } from "framer-motion";
 import React from "react";
+import AnimatedItem from "./Paginator/AnimatedItem";
 
 export default function AnimatedList({
   children,
@@ -11,13 +12,9 @@ export default function AnimatedList({
   return (
     <LazyMotion features={domAnimation}>
       {React.Children.map(children, (child, index) => (
-        <m.div
-          animate={{ opacity: 1, y: 0 }}
-          initial={{ opacity: 0, y: 30 }}
-          transition={{ delay: index * 0.15, ease: "easeOut" }}
-        >
+        <AnimatedItem key={`animated-item-${index}`} index={index} animated>
           {child}
-        </m.div>
+        </AnimatedItem>
       ))}
     </LazyMotion>
   );

--- a/src/components/Paginator/AnimatedItem.tsx
+++ b/src/components/Paginator/AnimatedItem.tsx
@@ -16,7 +16,6 @@ export default function AnimatedItem({
       <m.div
         animate={{ opacity: 1, y: 0 }}
         initial={{ opacity: 0, y: 30 }}
-        exit={{ opacity: 0, y: 30 }}
         transition={{ delay: index * 0.15, ease: "easeOut" }}
       >
         {children}

--- a/src/components/Paginator/AnimatedItem.tsx
+++ b/src/components/Paginator/AnimatedItem.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { m } from "framer-motion";
+
+export default function AnimatedItem({
+  animated,
+  index,
+  children,
+}: {
+  animated?: boolean;
+  index: number;
+  children: React.ReactNode;
+}) {
+  if (animated) {
+    return (
+      <m.div
+        animate={{ opacity: 1, y: 0 }}
+        initial={{ opacity: 0, y: 30 }}
+        exit={{ opacity: 0, y: 30 }}
+        transition={{ delay: index * 0.15, ease: "easeOut" }}
+      >
+        {children}
+      </m.div>
+    );
+  } else {
+    return children;
+  }
+}

--- a/src/components/Paginator/index.tsx
+++ b/src/components/Paginator/index.tsx
@@ -58,7 +58,7 @@ export default function Paginator<T>({
         <Fragment key={`item-page-${pageIdx}`}>
           {items.map((i: T, idx: number) => {
             const key = keyGenerator(i, pageIdx);
-            console.log(key);
+
             return (
               <>
                 <AnimatedItem animated={animated} index={idx} key={key}>

--- a/src/components/Paginator/index.tsx
+++ b/src/components/Paginator/index.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { SearchMeta } from "@/types/Search";
+import { domAnimation, LazyMotion } from "framer-motion";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { Spinner } from "react-bootstrap";
 import { InView } from "react-intersection-observer";
-
-const paginatorAnimations = {};
+import AnimatedItem from "./AnimatedItem";
 
 interface IPaginator<T> {
   data: T[];
@@ -13,7 +13,8 @@ interface IPaginator<T> {
   getData: (page: number) => Promise<{ data: T[]; meta: SearchMeta }>;
   keyGenerator: (item: T, page: number) => string;
   ItemComponent: React.FC<{ item: T; page: number; index: number }>;
-  ListEndComponent?: React.FC<{ index: number }>;
+  ListEndComponent?: React.FC;
+  animated?: boolean;
 }
 
 export default function Paginator<T>({
@@ -23,6 +24,7 @@ export default function Paginator<T>({
   keyGenerator,
   ItemComponent,
   ListEndComponent,
+  animated,
 }: IPaginator<T>) {
   const [page, setPage] = useState(meta.page);
   const [totalPages, setTotalPages] = useState(meta.totalPages);
@@ -51,24 +53,27 @@ export default function Paginator<T>({
   }, [page, pageLoading, itemPages, getData, hasNextPage]);
 
   return (
-    <>
-      {itemPages.map((items, pageIdx) =>
-        items.map((i: T, idx: number) => {
-          const key = keyGenerator(i, pageIdx);
-
-          return (
-            <Fragment key={`paginator-fragment-${key}`}>
-              <ItemComponent item={i} page={pageIdx} index={idx} key={key} />
-              {ListEndComponent &&
-                !hasNextPage &&
-                pageIdx === totalPages - 1 &&
-                idx === items.length - 1 && (
-                  <ListEndComponent key={"list-end-" + key} index={idx + 1} />
-                )}
-            </Fragment>
-          );
-        })
-      )}
+    <LazyMotion features={domAnimation}>
+      {itemPages.map((items, pageIdx) => (
+        <Fragment key={`item-page-${pageIdx}`}>
+          {items.map((i: T, idx: number) => {
+            const key = keyGenerator(i, pageIdx);
+            console.log(key);
+            return (
+              <>
+                <AnimatedItem animated={animated} index={idx} key={key}>
+                  <ItemComponent item={i} page={pageIdx} index={idx} />
+                </AnimatedItem>
+              </>
+            );
+          })}
+          {ListEndComponent && !hasNextPage && pageIdx === totalPages - 1 && (
+            <AnimatedItem animated={animated} index={items.length}>
+              <ListEndComponent />
+            </AnimatedItem>
+          )}
+        </Fragment>
+      ))}
       {/* When user scrolls to the end of the list, InView triggers getMore() */}
       <InView
         as="div"
@@ -78,6 +83,6 @@ export default function Paginator<T>({
       >
         {pageLoading && <Spinner animation="border" />}
       </InView>
-    </>
+    </LazyMotion>
   );
 }


### PR DESCRIPTION
## 🛠️ Changes
Gets rid of adhoc animation declarations and consolidates them to Paginator, enabled with the optional `animated` prop.

## 🧪 Testing
Try loading and searching various lists in the app. Note: Agent reviews do not use Paginator so they use the more generic AnimatedList
