### PR TITLE
[PRO-377] Account unconfirmed UI

### DIFF
--- a/src/app/(main-layout)/account/_components/AccountSettingsRow.tsx
+++ b/src/app/(main-layout)/account/_components/AccountSettingsRow.tsx
@@ -13,11 +13,11 @@ export default function AccountSettingsRow({
 }: IAccountSettingsRow) {
   return (
     <>
-      <Col xs={7}>
+      <Col xs={8}>
         <h4>{title}</h4>
         <p>{detail}</p>
       </Col>
-      <Col xs={5}>
+      <Col xs={4}>
         <div className="text-end">{action}</div>
       </Col>
     </>

--- a/src/app/(main-layout)/account/page.tsx
+++ b/src/app/(main-layout)/account/page.tsx
@@ -15,7 +15,7 @@ export default async function Page() {
   return (
     <div>
       <PageHeader title={t("account.title")} showBack />
-      <AccountSettings />
+      <AccountSettings user={user} />
     </div>
   );
 }

--- a/src/app/confirmations/[token]/page.tsx
+++ b/src/app/confirmations/[token]/page.tsx
@@ -11,13 +11,15 @@ export default function Page({ params }: { params: { token: string } }) {
   const t = useTranslations();
   const router = useRouter();
   async function accountConfirmation() {
-    const result = await confirmAccount(params.token);
-    if (!result) {
-      toast.error(t("account.confirmation.error"));
-    } else {
+    try {
+      await confirmAccount(params.token);
+
       toast.success(t("account.confirmation.success"));
+    } catch (e) {
+      toast.error(t("account.confirmation.error"));
+    } finally {
+      router.replace("/rate-my-po");
     }
-    router.replace("/");
   }
 
   useEffect(() => {
@@ -25,11 +27,9 @@ export default function Page({ params }: { params: { token: string } }) {
   });
 
   return (
-    <>
-      <div className="text-center vertical-rhythm">
-        <p>{t("account.confirmation.loading")}</p>
-        <Spinner />
-      </div>
-    </>
+    <div className="text-center vertical-rhythm">
+      <p>{t("account.confirmation.loading")}</p>
+      <Spinner />
+    </div>
   );
 }

--- a/src/app/confirmations/page.tsx
+++ b/src/app/confirmations/page.tsx
@@ -1,11 +1,14 @@
 import ConfirmEmail from "@/components/login/ConfirmEmail";
 import { getUser } from "@/lib/session";
+import { redirect } from "next/navigation";
 
 export default async function Page() {
   const user = await getUser();
   const email = user?.email;
+
   if (!email) {
-    return null;
+    return redirect("/");
   }
+
   return <ConfirmEmail email={email} />;
 }

--- a/src/components/AsyncButton.tsx
+++ b/src/components/AsyncButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import classNames from "classnames";
 import Button, { ButtonProps } from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 import { useFormStatus } from "react-dom";
@@ -19,19 +20,17 @@ export default function AsyncButton({
 
   return (
     <Button disabled={isLoading || disabled} {...props}>
-      {isLoading ? (
-        <>
-          <Spinner
-            size="sm"
-            role="status"
-            className="align-middle"
-            animation="border"
-            variant="black"
-          />
-        </>
-      ) : (
-        children
-      )}
+      <div className="position-relative w-100 h-100 d-flex justify-content-center align-items-center">
+        <Spinner
+          size="sm"
+          role="status"
+          animation="border"
+          className={classNames("position-absolute", {
+            "opacity-0": !isLoading,
+          })}
+        />
+        <div className={classNames({ "opacity-0": isLoading })}>{children}</div>
+      </div>
     </Button>
   );
 }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -88,7 +88,11 @@ export default async function Menu() {
               </NavLink>
             ) : (
               <NavItem>
-                <Link className="btn btn-primary" href="/login" scroll={false}>
+                <Link
+                  className="btn btn-primary"
+                  href="/login/signup"
+                  scroll={false}
+                >
                   {t("navigation.signUp")}
                 </Link>
               </NavItem>

--- a/src/components/login/ConfirmEmail.tsx
+++ b/src/components/login/ConfirmEmail.tsx
@@ -2,12 +2,11 @@
 
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { Button } from "react-bootstrap";
 import { useSearchParams } from "next/navigation";
 
 export default function ConfirmEmail({ email }: { email: string }) {
   const t = useTranslations();
-  const callbackURL = useSearchParams().get("callbackURL") || "";
+  const callbackURL = useSearchParams().get("callbackURL") ?? "/rate-my-po";
 
   return (
     <div className="d-block p-4">
@@ -20,7 +19,9 @@ export default function ConfirmEmail({ email }: { email: string }) {
       </p>
       <p>{t("login.loginConfirmSignupDetail2")}</p>
       <div className="text-center mt-5">
-        <Button href={callbackURL || "/"}>{t("shared.OK")}</Button>
+        <Link className="btn btn-primary" href={callbackURL}>
+          {t("shared.OK")}
+        </Link>
       </div>
       <div className="text-center mt-5">
         <Link href="/terms-of-service" className="link">

--- a/src/components/login/ForgotPasswordForm.tsx
+++ b/src/components/login/ForgotPasswordForm.tsx
@@ -2,15 +2,15 @@
 import Input from "../Input";
 import { useTranslations } from "next-intl";
 import AsyncButton from "../AsyncButton";
-import {
-  IRequestPasswordResetFormState,
-  requestPasswordReset,
-} from "@/lib/actions/account";
+import { requestPasswordReset } from "@/lib/actions/account";
 import z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useCallback } from "react";
 
+export interface IRequestPasswordResetFormState {
+  email: string;
+}
 export default function ForgotPasswordForm() {
   const t = useTranslations();
   const schema = z.object({

--- a/src/components/login/SignupForm.tsx
+++ b/src/components/login/SignupForm.tsx
@@ -10,9 +10,8 @@ import { useCallback } from "react";
 import Input from "../Input";
 import AsyncButton from "../AsyncButton";
 import { useRouter } from "next/navigation";
-import toast from "react-hot-toast";
 
-export default function SignupForm({ callbackURL }: { callbackURL?: string }) {
+export default function SignupForm() {
   const t = useTranslations();
   const schema = z.object({
     signUpEmail: z
@@ -23,7 +22,6 @@ export default function SignupForm({ callbackURL }: { callbackURL?: string }) {
       .string()
       .min(1, t("login.passwordRequired"))
       .min(8, t("shared.passwordLengthError")),
-    callbackURL: z.string().optional(),
   });
   const router = useRouter();
   const { register, handleSubmit, getFieldState, formState } =
@@ -32,25 +30,14 @@ export default function SignupForm({ callbackURL }: { callbackURL?: string }) {
       defaultValues: {
         signUpEmail: "",
         password: "",
-        callbackURL,
       },
       resolver: zodResolver(schema),
     });
 
   async function onSubmit(data: ISignupFormState) {
-    const { error, email, isConfirmed } = await signUp(data);
-    if (error) {
-      toast.error(error);
-    } else {
-      if (isConfirmed) {
-        router.replace(callbackURL || "/");
-      } else if (callbackURL) {
-        router.replace(
-          `/confirmations?callbackURL=${encodeURIComponent(callbackURL)}`
-        );
-      } else {
-        router.replace(`/confirmations`);
-      }
+    const { error } = await signUp(data);
+    if (!error) {
+      router.replace(`/confirmations`);
     }
   }
 
@@ -71,7 +58,6 @@ export default function SignupForm({ callbackURL }: { callbackURL?: string }) {
         {t("login.signupTitleHelper")}
       </div>
       <form onSubmit={handleSubmit(onSubmit)} className="vertical-rhythm">
-        <input type="hidden" name="callbackURL" value={callbackURL} />
         <Input
           size="lg"
           controlId={`signup-email`}
@@ -96,7 +82,6 @@ export default function SignupForm({ callbackURL }: { callbackURL?: string }) {
               size="lg"
               className="w-100"
               variant="primary"
-              disabled={!formState.isValid}
               type="submit"
             >
               {t("login.signup")}

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -11,13 +11,7 @@ import { MessageKeys } from "next-intl";
 /**
  * Initiates a password reset request for "forgot password" flow.
  */
-export interface IRequestPasswordResetFormState {
-  email: string;
-}
-
-export async function requestPasswordReset({
-  email,
-}: IRequestPasswordResetFormState) {
+export async function requestPasswordReset({ email }: { email: string }) {
   const t = await getTranslations();
 
   const response = await new Api().post("/auth/password_resets", {


### PR DESCRIPTION
## 🛠️ Changes
Adds unconfirmed message and resend button to Account settings page
<img width="400" alt="image" src="https://github.com/user-attachments/assets/80857ae6-9df1-4081-b036-556919046d3d">

* Signs the user in on confirmation (there's an accompanying API PR forthcoming)
* Normalizes the way we set the session cookie and sign the user in with the `signIn()` session function.
* Removes the unused callbackURL from the sign in flow for now, added a ticket to do these redirects in a different way.
* Changes the redirect after signing up/confirmation to `rate-my-po`. I think we should think more about what the signed-in user experience is, cause the home page feels a little weird since it doesn't show any indication of being signed in.

## 🧪 Testing
* Try registering a new user and visiting the `/account` page. Test the resend button. Sign out.
* Try confirming the account. See that the user is redirected to `rate-my-po` and is now signed in.
