### PR TITLE
Adding moderation modal for not-yet-approved comments and policy acknowledgement

### DIFF
--- a/src/app/(main-layout)/agents/[agentId]/_components/ReviewCard/ReviewCardComment.tsx
+++ b/src/app/(main-layout)/agents/[agentId]/_components/ReviewCard/ReviewCardComment.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import { useTranslations } from "next-intl";
 import Comment from "@/types/Comment";
+import ModerationModal from "@/components/ModerationModal";
+import { useState } from "react";
 
 interface IReviewCardComment {
   comment: Comment;
@@ -9,22 +13,34 @@ export default function ReviewCardComment({ comment }: IReviewCardComment) {
   const t = useTranslations();
   const { body, status } = comment;
   const isPublished = status === "published";
+  const [showModerationModal, setShowModerationModal] = useState(false);
 
   return (
-    <div>
-      <h4>{t("rate_agent.additionalComments")}</h4>
-      {!isPublished && (
-        <div
-          className="bg-meyer-lemon bg-opacity-75 mb-3 rounded"
-          style={{ padding: "12px" }}
-        >
-          <span>{t("rate_agent.unpublishedCommentHeader")}</span>{" "}
-          <a className="link" role="button">
-            {t("rate_agent.unpublishedCommentHeaderLink")}
-          </a>
-        </div>
-      )}
-      <p>{body}</p>
-    </div>
+    <>
+      <div>
+        <h4>{t("rate_agent.additionalComments")}</h4>
+        {!isPublished && (
+          <div
+            className="bg-meyer-lemon bg-opacity-75 mb-3 rounded"
+            style={{ padding: "12px" }}
+          >
+            <span>{t("rate_agent.unpublishedCommentHeader")}</span>{" "}
+            <a
+              className="link"
+              role="button"
+              onClick={() => setShowModerationModal(true)}
+            >
+              {t("rate_agent.unpublishedCommentHeaderLink")}
+            </a>
+          </div>
+        )}
+        <p>{body}</p>
+      </div>
+      <ModerationModal
+        show={showModerationModal}
+        closeButton={true}
+        onHide={() => setShowModerationModal(false)}
+      />
+    </>
   );
 }

--- a/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
+++ b/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
@@ -19,6 +19,7 @@ export async function generateStaticParams() {
     "ethical-principles",
     "vote",
     "terms-of-service",
+    "community-posting-guidelines",
   ];
 
   const pages = [];

--- a/src/app/(main-layout)/rate-my-po/_components/AcknowledgePolicy.tsx
+++ b/src/app/(main-layout)/rate-my-po/_components/AcknowledgePolicy.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import ModerationModal from "@/components/ModerationModal";
+import { useState } from "react";
+
+export default function AcknowledgePolicyModal({
+  isPolicyAcknowledged,
+}: {
+  isPolicyAcknowledged: boolean;
+}) {
+  const [isAcknowledged, setAcknowledged] = useState(isPolicyAcknowledged);
+  return (
+    <ModerationModal
+      show={!isAcknowledged}
+      closeButton={false}
+      onHide={() => setAcknowledged(true)}
+    />
+  );
+}

--- a/src/app/(main-layout)/rate-my-po/page.tsx
+++ b/src/app/(main-layout)/rate-my-po/page.tsx
@@ -4,6 +4,9 @@ import RateMyPoSearchbar from "./_components/RateMyPoSearchBar";
 import RateMyPoSearchResults from "./_components/RateMyPoSearchResults";
 import { Suspense } from "react";
 import { metaTitle } from "@/lib/metadataUtils";
+import AcknowledgePolicyModal from "./_components/AcknowledgePolicy";
+import { getSession } from "@/lib/session";
+import Api from "@/lib/api";
 
 export async function generateMetadata() {
   const t = await getTranslations("home");
@@ -21,14 +24,25 @@ export default async function Page({
   };
 }) {
   const t = await getTranslations();
+  const session = await getSession();
+  const { user } = await new Api(session?.apiToken)
+    .get("/auth/reauthenticate")
+    .then((res) => res.json());
 
   return (
-    <div className="vertical-rhythm">
-      <PageHeader title={t("rate_my_po.title")} />
-      <RateMyPoSearchbar />
-      <Suspense>
-        <RateMyPoSearchResults searchText={searchParams?.search} />
-      </Suspense>
-    </div>
+    <>
+      <div className="vertical-rhythm">
+        <PageHeader title={t("rate_my_po.title")} />
+        <RateMyPoSearchbar />
+        <Suspense>
+          <RateMyPoSearchResults searchText={searchParams?.search} />
+        </Suspense>
+      </div>
+      {user && (
+        <AcknowledgePolicyModal
+          isPolicyAcknowledged={user.isPolicyAcknowledged}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/ModerationModal.tsx
+++ b/src/components/ModerationModal.tsx
@@ -45,7 +45,9 @@ export default function ModerationModal(props: IPopUp) {
           </ul>
           <p>
             You can see more of our community moderation guidelines{" "}
-            <Link href="/community-posting-guidelines">here.</Link>
+            <Link href="/content/en-US/community-posting-guidelines">
+              here.
+            </Link>
           </p>
           <p>
             During the review process, we may email you to make changes to your
@@ -56,7 +58,9 @@ export default function ModerationModal(props: IPopUp) {
             .
           </p>
           <div className="text-center">
-            <Link href="/terms-of-service">Read our terms of service</Link>
+            <Link href="/content/en-US/terms-of-service">
+              Read our terms of service
+            </Link>
           </div>
           {!props.closeButton && (
             <div className="text-center">

--- a/src/components/ModerationModal.tsx
+++ b/src/components/ModerationModal.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import PopUp, { IPopUp } from "./PopUp";
+import Image from "next/image";
+import { Button } from "react-bootstrap";
+import { acknowledgePolicy } from "@/lib/actions/account";
+
+export default function ModerationModal(props: IPopUp) {
+  const ackPolicy = async () => {
+    const result = await acknowledgePolicy();
+    if (result) {
+      props.onHide?.();
+    }
+  };
+  return (
+    <PopUp {...props} closeButton={props.closeButton}>
+      <div style={{ maxWidth: "300px", margin: "0 auto" }}>
+        <div className="d-flex flex-column align-items-center justify-content-center vertical-rhythm">
+          <Image src="/images/icon.svg" alt="icon" width={45} height={45} />
+          <h3 className="text-center">Comments are hidden until approved</h3>
+          <p>
+            Your safety and the safety of the community is very important to us.
+            For that reason, we will hide any comments you give until we approve
+            them.
+          </p>
+          <p>
+            Once approved, the comment will be visible on the Rate My PO page
+            for the public to see.
+          </p>
+          <p>We review comments for the following things:</p>
+          <ul>
+            <li>
+              Information that could identify you to a parole officer including
+              personal information and details of events
+            </li>
+            <li>
+              Information about a parole officer that could put them at risk of
+              personal harm
+            </li>
+            <li>
+              Descriptions of harmful activity or events that could lead to
+              serious retaliation
+            </li>
+          </ul>
+          <p>
+            You can see more of our community moderation guidelines{" "}
+            <Link href="/community-posting-guidelines">here.</Link>
+          </p>
+          <p>
+            During the review process, we may email you to make changes to your
+            comment. If you have any questions, contact us at{" "}
+            <a href="mailto:info@projectprotocol.org">
+              info@projectprotocol.org
+            </a>
+            .
+          </p>
+          <div className="text-center">
+            <Link href="/terms-of-service">Read our terms of service</Link>
+          </div>
+          {!props.closeButton && (
+            <div className="text-center">
+              <Button onClick={ackPolicy}>I understand</Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </PopUp>
+  );
+}

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -7,6 +7,7 @@ import { getTranslations } from "next-intl/server";
 import { flashError, flashSuccess } from "../flash-messages";
 import { snakeCaseKeys } from "../transformKeys";
 import { MessageKeys } from "next-intl";
+import { revalidatePath } from "next/cache";
 
 /**
  * Initiates a password reset request for "forgot password" flow.
@@ -153,5 +154,6 @@ export async function acknowledgePolicy() {
     return false;
   }
 
+  revalidatePath("/auth/reauthenticate");
   return true;
 }

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -144,3 +144,14 @@ export async function deleteAccount({ password }: IDeleteAccountFormState) {
   flashSuccess(t("account.delete.success"));
   await destroySession();
 }
+
+export async function acknowledgePolicy() {
+  const session = await getSession();
+  const response = await new Api(session?.apiToken).patch("/profile/policy");
+
+  if (!response.ok) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -7,6 +7,7 @@ export const contentIds = {
   "how-does-it-work": "1BQDLK4P2L1E0DmCwLOrDR",
   vote: "6VgcyUQKmZTr955WYmlhr8",
   "terms-of-service": "1acLWVokjkixcvTh0b3gup",
+  "community-posting-guidelines": "fYYpah3B5mppvE7rXY1gY",
 };
 
 export type ContentfulKey = keyof typeof contentIds;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,7 +1,7 @@
 type User = {
-  email: string
-  isConfirmed: boolean
-  confirmationSentAt?: string
-}
+  email: string;
+  isConfirmed: boolean;
+  confirmationSentAt?: string;
+};
 
-export default User
+export default User;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -2,6 +2,7 @@ type User = {
   email: string;
   isConfirmed: boolean;
   confirmationSentAt?: string;
+  isPolicyAcknowledged: boolean;
 };
 
 export default User;


### PR DESCRIPTION
## 🛠️ Changes

This adds the moderation information modal for not-yet-approved comments and policy acknowledgement.

## 🧪 Testing

<img width="408" alt="截屏2024-08-19 上午11 56 31" src="https://github.com/user-attachments/assets/08e6cc88-0328-4797-8681-ff3d2e4b0313">
<img width="1036" alt="截屏2024-08-20 下午12 40 36" src="https://github.com/user-attachments/assets/bf008d30-cfc4-4b16-b07e-c7b6560c7b73">
<img width="853" alt="截屏2024-08-20 下午12 41 03" src="https://github.com/user-attachments/assets/ccd7f21e-0f1f-4709-ad2d-f08bdbfa63fc">

