### PR TITLE
[PRO-382] Social media share images and preview

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Viewport } from "next";
+import type { Viewport } from "next";
 import { Source_Sans_3 } from "next/font/google";
 import "@/styles/index.scss";
 import { NextIntlClientProvider } from "next-intl";
@@ -27,6 +27,7 @@ export const viewPort: Viewport = {
 
 export async function generateMetadata() {
   const t = await getTranslations();
+  const host = process.env.HOST ?? "http://localhost:3001";
   return {
     title: metaTitle(t("home.title")),
     description: t("home.welcomeMessage"),
@@ -35,6 +36,7 @@ export async function generateMetadata() {
       title: "Project Protocol",
       statusBarStyle: "default",
     },
+    metadataBase: new URL(host),
   };
 }
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,66 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+// Image metadata
+export const alt = "Project Protocol logo";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+// Image generation
+export default async function Image() {
+  return new ImageResponse(
+    (
+      // ImageResponse JSX element
+      <div
+        style={{
+          fontSize: 128,
+          background: "#f8f7f8",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <section
+          style={{
+            width: 400,
+            height: 400,
+            display: "flex",
+            background: "#fff",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: "50%",
+          }}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="220"
+            height="220"
+            viewBox="0 0 49.63 55.667"
+          >
+            <path
+              fill="#ffa727"
+              d="M973.978,3114.919h-23.5a4.792,4.792,0,0,0-4.793,4.792v11.751h12.656a3.888,3.888,0,0,1,3.888,3.888v12.656h11.751a4.793,4.793,0,0,0,4.792-4.793v-23.5A4.792,4.792,0,0,0,973.978,3114.919Z"
+              transform="translate(-929.14 -3114.919)"
+            />
+            <path
+              fill="#f06748"
+              d="M945.683,3143.213v-11.751H933.028a3.888,3.888,0,0,0-3.888,3.888v31.341a3.888,3.888,0,0,0,6.341,3.016l5.27-4.286a3.888,3.888,0,0,1,2.453-.872h15.135a3.888,3.888,0,0,0,3.888-3.888v-12.655H950.476A4.793,4.793,0,0,1,945.683,3143.213Z"
+              transform="translate(-929.14 -3114.919)"
+            />
+          </svg>
+        </section>
+      </div>
+    ),
+    // ImageResponse options
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @next/next/no-img-element */
+
 import { ImageResponse } from "next/og";
 
 export const runtime = "edge";
@@ -13,6 +15,10 @@ export const contentType = "image/png";
 
 // Image generation
 export default async function Image() {
+  const logoSrc = await fetch(
+    new URL("../../public/images/landing-image.jpeg", import.meta.url)
+  ).then((res) => res.arrayBuffer());
+
   return new ImageResponse(
     (
       // ImageResponse JSX element
@@ -25,14 +31,36 @@ export default async function Image() {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
+          position: "relative",
         }}
       >
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            position: "absolute",
+            backgroundColor: "black",
+          }}
+        />
+        <img
+          src={logoSrc as unknown as string} // Crazy hack to make typescript shut up
+          width="100%"
+          height="100%"
+          style={{
+            position: "absolute",
+            backgroundColor: "black",
+            opacity: 0.95,
+            filter: "blur(10px)",
+            objectFit: "cover",
+          }}
+          alt="Background image"
+        />
         <section
           style={{
             width: 400,
             height: 400,
             display: "flex",
-            background: "#fff",
+            background: "rgba(255, 255, 255, 0.95)",
             alignItems: "center",
             justifyContent: "center",
             borderRadius: "50%",


### PR DESCRIPTION
## 🛠️ Changes
Adds social media share image via `opengraph-image.tsx`

<img width="377" alt="image" src="https://github.com/user-attachments/assets/a90bd28b-6bf8-4090-8fb7-3300f4d40efa">


## 🧪 Testing
~~Try copying the preview url and pasting it in a slack message~~

I tried a few things to set the right host in deploy previews, but they're kind of hacky. The `og:*` meta tag urls are configured to use the HOST variable. Since the preview host changes every time, it'd be tricky to make it work so we'll just have to YOLO this one (it should be fine).
