### PR TITLE
Fix Paginator key error

### DIFF
--- a/src/components/Paginator/index.tsx
+++ b/src/components/Paginator/index.tsx
@@ -60,11 +60,9 @@ export default function Paginator<T>({
             const key = keyGenerator(i, pageIdx);
 
             return (
-              <>
-                <AnimatedItem animated={animated} index={idx} key={key}>
-                  <ItemComponent item={i} page={pageIdx} index={idx} />
-                </AnimatedItem>
-              </>
+              <AnimatedItem animated={animated} index={idx} key={key}>
+                <ItemComponent item={i} page={pageIdx} index={idx} />
+              </AnimatedItem>
             );
           })}
           {ListEndComponent && !hasNextPage && pageIdx === totalPages - 1 && (


### PR DESCRIPTION
Remove unneeded fragment around AnimatedItem. This was causing a lot of noise in console because elements in a list need to have unique keys, which the wrapping fragment did not.