### PR TITLE
[PRO-398 +] Content/Footer pages updates

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,10 @@ let nextConfig = {
         protocol: "https",
         hostname: "s2.googleusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "images.ctfassets.net",
+      },
     ],
   },
   logging: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,6 +22,10 @@ let nextConfig = {
         protocol: "https",
         hostname: "images.ctfassets.net",
       },
+      {
+        protocol: "https",
+        hostname: "res.cloudinary.com",
+      },
     ],
   },
   logging: {

--- a/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
+++ b/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
@@ -1,7 +1,10 @@
 // note spanish locale in contentful is es-US
 
 import { ALL_LOCALES } from "@/i18n";
-import ContentfulClient, { ContentfulKey, contentIds } from "@/lib/contentful";
+import ContentfulClient, {
+  ContentfulPageKey,
+  contentfulPageIds,
+} from "@/lib/contentful";
 import { Document } from "@contentful/rich-text-types";
 import renderRichText from "@/lib/renderRichText";
 import "@/styles/content-pages.scss";
@@ -15,7 +18,7 @@ export async function generateStaticParams() {
 
   const pages = [];
   for (const locale of locales) {
-    for (const slug of Object.keys(contentIds)) {
+    for (const slug of Object.keys(contentfulPageIds)) {
       pages.push({ locale, slug });
     }
   }
@@ -25,7 +28,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: { locale: string; slug: ContentfulKey };
+  params: { locale: string; slug: ContentfulPageKey };
 }) {
   const data = await getContent(params.locale, params.slug);
   const title = data.fields.title as string;
@@ -34,9 +37,9 @@ export async function generateMetadata({
   };
 }
 
-async function getContent(locale: string, slug: ContentfulKey) {
+async function getContent(locale: string, slug: ContentfulPageKey) {
   const contentfulLocale = locale === "es-MX" ? "es-US" : locale;
-  const data = await ContentfulClient.getEntry(contentIds[slug], {
+  const data = await ContentfulClient.getEntry(contentfulPageIds[slug], {
     locale: contentfulLocale,
   });
   return data;
@@ -53,7 +56,7 @@ type CoverImage = {
 export default async function Page({
   params,
 }: {
-  params: { slug: ContentfulKey; locale: string };
+  params: { slug: ContentfulPageKey; locale: string };
 }) {
   const data = await getContent(params.locale, params.slug);
   const title = data.fields.title as string;

--- a/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
+++ b/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
@@ -12,19 +12,10 @@ export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const locales = ALL_LOCALES;
-  const slugs = [
-    "about",
-    "why-email",
-    "how-does-it-work",
-    "ethical-principles",
-    "vote",
-    "terms-of-service",
-    "community-posting-guidelines",
-  ];
 
   const pages = [];
   for (const locale of locales) {
-    for (const slug of slugs) {
+    for (const slug of Object.keys(contentIds)) {
       pages.push({ locale, slug });
     }
   }
@@ -51,6 +42,14 @@ async function getContent(locale: string, slug: ContentfulKey) {
   return data;
 }
 
+type CoverImage = {
+  fields: {
+    file: {
+      url: string;
+    };
+  };
+};
+
 export default async function Page({
   params,
 }: {
@@ -60,8 +59,14 @@ export default async function Page({
   const title = data.fields.title as string;
   const body = data.fields.body as Document;
 
+  let coverImageSrc;
+  if (!!data.fields.coverImage) {
+    const url = (data.fields.coverImage as CoverImage).fields.file.url;
+    coverImageSrc = `https:${url}?w=1200`;
+  }
+
   return (
-    <ContentPage title={title}>
+    <ContentPage title={title} coverImageSrc={coverImageSrc}>
       <div className="content-page">{renderRichText(body)}</div>
     </ContentPage>
   );

--- a/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
+++ b/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
@@ -67,6 +67,13 @@ export default async function Page({
     const url = (data.fields.coverImage as CoverImage).fields.file.url;
     coverImageSrc = `https:${url}?w=1200`;
   }
+  /* eslint-disable no-console */
+  console.log(
+    "Building page",
+    params.slug,
+    "with image: ",
+    coverImageSrc ?? ""
+  );
 
   return (
     <ContentPage title={title} coverImageSrc={coverImageSrc}>

--- a/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
+++ b/src/app/(main-layout)/content/[locale]/[slug]/page.tsx
@@ -10,6 +10,7 @@ import renderRichText from "@/lib/renderRichText";
 import "@/styles/content-pages.scss";
 import ContentPage from "../_components/ContentPage";
 import { metaTitle } from "@/lib/metadataUtils";
+import { getCldImageUrl } from "next-cloudinary";
 
 export const dynamicParams = false;
 
@@ -45,14 +46,6 @@ async function getContent(locale: string, slug: ContentfulPageKey) {
   return data;
 }
 
-type CoverImage = {
-  fields: {
-    file: {
-      url: string;
-    };
-  };
-};
-
 export default async function Page({
   params,
 }: {
@@ -63,17 +56,10 @@ export default async function Page({
   const body = data.fields.body as Document;
 
   let coverImageSrc;
-  if (!!data.fields.coverImage) {
-    const url = (data.fields.coverImage as CoverImage).fields.file.url;
-    coverImageSrc = `https:${url}?w=1200`;
+  if (!!data.fields.cloudinaryImgId) {
+    let id = data.fields.cloudinaryImgId as string;
+    coverImageSrc = await getCldImageUrl({ src: id, width: 1200 });
   }
-  /* eslint-disable no-console */
-  console.log(
-    "Building page",
-    params.slug,
-    "with image: ",
-    coverImageSrc ?? ""
-  );
 
   return (
     <ContentPage title={title} coverImageSrc={coverImageSrc}>

--- a/src/app/(main-layout)/content/[locale]/_components/ContentCoverImage.tsx
+++ b/src/app/(main-layout)/content/[locale]/_components/ContentCoverImage.tsx
@@ -1,0 +1,40 @@
+import Image from "next/image";
+
+export default function ContentCoverImage({
+  coverImageSrc,
+  title,
+}: {
+  coverImageSrc: string;
+  title: string;
+}) {
+  return (
+    <div style={{ height: 350 }}>
+      <div
+        className="w-100 position-absolute"
+        style={{ height: 350, left: 0, right: 0 }}
+      >
+        <Image
+          src={coverImageSrc}
+          sizes="100vw"
+          priority
+          fill
+          style={{ objectFit: "cover" }}
+          alt={`Cover image for ${title}`}
+        />
+        <div
+          className="position-relative d-flex flex-column justify-content-end"
+          style={{
+            position: "absolute",
+            maxWidth: 600,
+            margin: "0 auto",
+            bottom: 0,
+            width: "100%",
+            height: "100%",
+          }}
+        >
+          <h1 className="pb-3 ps-3 ps-md-0 text-white">{title}</h1>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main-layout)/content/[locale]/_components/ContentCoverImage.tsx
+++ b/src/app/(main-layout)/content/[locale]/_components/ContentCoverImage.tsx
@@ -18,6 +18,7 @@ export default function ContentCoverImage({
           sizes="100vw"
           priority
           fill
+          quality={10}
           style={{ objectFit: "cover" }}
           alt={`Cover image for ${title}`}
         />

--- a/src/app/(main-layout)/content/[locale]/_components/ContentCoverImage.tsx
+++ b/src/app/(main-layout)/content/[locale]/_components/ContentCoverImage.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import styles from "./content-cover-image.module.scss";
+
 export default function ContentCoverImage({
   coverImageSrc,
   title,
@@ -18,7 +19,6 @@ export default function ContentCoverImage({
           sizes="100vw"
           priority
           fill
-          quality={10}
           style={{ objectFit: "cover" }}
           alt={`Cover image for ${title}`}
         />

--- a/src/app/(main-layout)/content/[locale]/_components/ContentCoverImage.tsx
+++ b/src/app/(main-layout)/content/[locale]/_components/ContentCoverImage.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-
+import styles from "./content-cover-image.module.scss";
 export default function ContentCoverImage({
   coverImageSrc,
   title,
@@ -21,6 +21,7 @@ export default function ContentCoverImage({
           style={{ objectFit: "cover" }}
           alt={`Cover image for ${title}`}
         />
+        <div className={styles.coverImageOverlay} />
         <div
           className="position-relative d-flex flex-column justify-content-end"
           style={{

--- a/src/app/(main-layout)/content/[locale]/_components/ContentPage.tsx
+++ b/src/app/(main-layout)/content/[locale]/_components/ContentPage.tsx
@@ -15,17 +15,19 @@ export default function ContentPage({
 }: IContentPage) {
   const TitleEl = <span className="d-md-none">{title}</span>;
   return (
-    <div className="pb-4 vertical-rhythm">
-      <PageHeader title={TitleEl} showBack />
-      {coverImageSrc ? (
-        <ContentCoverImage
-          coverImageSrc={coverImageSrc}
-          title={title as string}
-        />
-      ) : (
-        <h1 className="display-5 fw-bold">{title}</h1>
-      )}
-      {children}
+    <div className="pb-4">
+      <PageHeader title={TitleEl} showBack hideOnDesktop />
+      <div className="vertical-rhythm">
+        {coverImageSrc ? (
+          <ContentCoverImage
+            coverImageSrc={coverImageSrc}
+            title={title as string}
+          />
+        ) : (
+          <h1 className="display-5 fw-bold mt-4">{title}</h1>
+        )}
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/app/(main-layout)/content/[locale]/_components/ContentPage.tsx
+++ b/src/app/(main-layout)/content/[locale]/_components/ContentPage.tsx
@@ -1,16 +1,30 @@
 import PageHeader from "@/components/PageHeader";
+import ContentCoverImage from "./ContentCoverImage";
 
 interface IContentPage {
   title: string | JSX.Element;
   children: React.ReactNode;
+  coverImageSrc?: string;
 }
 
 /** Multi-purpose page layout with a page title and icon */
-export default function ContentPage({ title, children }: IContentPage) {
+export default function ContentPage({
+  title,
+  children,
+  coverImageSrc,
+}: IContentPage) {
+  const TitleEl = <span className="d-md-none">{title}</span>;
   return (
     <div className="pb-4 vertical-rhythm">
-      <PageHeader title="" showBack />
-      <h1 className="display-5 fw-bold">{title}</h1>
+      <PageHeader title={TitleEl} showBack />
+      {coverImageSrc ? (
+        <ContentCoverImage
+          coverImageSrc={coverImageSrc}
+          title={title as string}
+        />
+      ) : (
+        <h1 className="display-5 fw-bold">{title}</h1>
+      )}
       {children}
     </div>
   );

--- a/src/app/(main-layout)/content/[locale]/_components/ContentPage.tsx
+++ b/src/app/(main-layout)/content/[locale]/_components/ContentPage.tsx
@@ -24,7 +24,7 @@ export default function ContentPage({
             title={title as string}
           />
         ) : (
-          <h1 className="display-5 fw-bold mt-4">{title}</h1>
+          <h1 className="display-5 fw-bold mt-5">{title}</h1>
         )}
         {children}
       </div>

--- a/src/app/(main-layout)/content/[locale]/_components/content-cover-image.module.scss
+++ b/src/app/(main-layout)/content/[locale]/_components/content-cover-image.module.scss
@@ -1,0 +1,10 @@
+.coverImageOverlay {
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0) 50%,
+    rgba(0, 0, 0, 0.4) 75.8%
+  );
+  height: 350px;
+  width: 100vw;
+  position: absolute;
+}

--- a/src/app/(main-layout)/content/[locale]/_components/content-cover-image.module.scss
+++ b/src/app/(main-layout)/content/[locale]/_components/content-cover-image.module.scss
@@ -5,6 +5,6 @@
     rgba(0, 0, 0, 0.4) 75.8%
   );
   height: 350px;
-  width: 100vw;
+  max-width: 100vw;
   position: absolute;
 }

--- a/src/app/(main-layout)/layout.tsx
+++ b/src/app/(main-layout)/layout.tsx
@@ -11,7 +11,7 @@ export default async function Layout({
   return (
     <main className="d-flex flex-column min-vh-100">
       <Menu />
-      <Container className="p-3 flex-grow-1" style={{ maxWidth: 935 }}>
+      <Container className="px-3 flex-grow-1" style={{ maxWidth: 935 }}>
         {children}
       </Container>
       <Footer />

--- a/src/app/(main-layout)/rate-my-po/page.tsx
+++ b/src/app/(main-layout)/rate-my-po/page.tsx
@@ -31,8 +31,8 @@ export default async function Page({
 
   return (
     <>
+      <PageHeader title={t("rate_my_po.title")} />
       <div className="vertical-rhythm">
-        <PageHeader title={t("rate_my_po.title")} />
         <RateMyPoSearchbar />
         <Suspense>
           <RateMyPoSearchResults searchText={searchParams?.search} />

--- a/src/app/(main-layout)/resources/page.tsx
+++ b/src/app/(main-layout)/resources/page.tsx
@@ -24,13 +24,15 @@ export default async function Page({
   const t = await getTranslations();
 
   return (
-    <div className="vertical-rhythm">
+    <>
       <PageHeader title={t("resources.title")} />
-      <ResourceSearchBar />
-      <ResourceFilters searchParams={searchParams} />
-      <Suspense fallback={<ResourcesLoadingPlaceholder />}>
-        <ResourcesList searchParams={searchParams} />
-      </Suspense>
-    </div>
+      <div className="vertical-rhythm">
+        <ResourceSearchBar />
+        <ResourceFilters searchParams={searchParams} />
+        <Suspense fallback={<ResourcesLoadingPlaceholder />}>
+          <ResourcesList searchParams={searchParams} />
+        </Suspense>
+      </div>
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,13 +17,13 @@ const ProgressBarWrapperNoSSR = dynamic(
 
 const font = Source_Sans_3({ subsets: ["latin"] });
 
-export const viewPort: Viewport = {
+export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   minimumScale: 1,
   maximumScale: 1,
   userScalable: false,
-  themeColor: { media: "(prefers-color-scheme: light)", color: "#f06748" },
+  themeColor: [{ media: "(prefers-color-scheme: light)", color: "#f06748" }],
 };
 
 export async function generateMetadata() {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,10 +11,6 @@ export default async function Footer() {
       label: t("whatIsProjectProtocol"),
     },
     {
-      url: urlPrefix("/how-does-it-work"),
-      label: t("howDoesItWork"),
-    },
-    {
       url: urlPrefix("/ethical-principles"),
       label: t("ethicalPrinciples"),
     },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,10 @@ export default async function Footer() {
   const locale = await getLocale();
   const urlPrefix = (path: string) => `/content/${locale}/${path}`;
   const links = [
-    { url: urlPrefix("/about"), label: t("about") },
+    {
+      url: urlPrefix("/what-is-project-protocol"),
+      label: t("whatIsProjectProtocol"),
+    },
     {
       url: urlPrefix("/how-does-it-work"),
       label: t("howDoesItWork"),

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,6 +11,10 @@ export default async function Footer() {
       label: t("whatIsProjectProtocol"),
     },
     {
+      url: urlPrefix("/the-team"),
+      label: t("theTeam"),
+    },
+    {
       url: urlPrefix("/ethical-principles"),
       label: t("ethicalPrinciples"),
     },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,22 +7,22 @@ export default async function Footer() {
   const urlPrefix = (path: string) => `/content/${locale}/${path}`;
   const links = [
     {
-      url: urlPrefix("/what-is-project-protocol"),
+      url: urlPrefix("what-is-project-protocol"),
       label: t("whatIsProjectProtocol"),
     },
     {
-      url: urlPrefix("/the-team"),
+      url: urlPrefix("the-team"),
       label: t("theTeam"),
     },
     {
-      url: urlPrefix("/ethical-principles"),
+      url: urlPrefix("ethical-principles"),
       label: t("ethicalPrinciples"),
     },
     {
-      url: urlPrefix("/terms-of-service"),
+      url: urlPrefix("terms-of-service"),
       label: t("termsOfService"),
     },
-    { url: urlPrefix("/contact-us"), label: t("contact") },
+    { url: urlPrefix("contact-us"), label: t("contact") },
   ];
 
   return (

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -9,17 +9,18 @@ interface IPageHeader {
   showAccount?: boolean;
   showBack?: boolean;
   leftAction?: JSX.Element;
+  hideOnDesktop?: boolean;
 }
 
 export default async function PageHeader({
   title,
   showBack = false,
+  hideOnDesktop,
 }: IPageHeader) {
   const user = await getUser();
   const t = await getTranslations();
-
   return (
-    <div className="py-2">
+    <div className={`py-3 ${hideOnDesktop ? "d-md-none" : ""}`}>
       {/* MOBILE PAGE HEADER */}
       <Row className="d-md-none">
         <Col>
@@ -61,7 +62,7 @@ export default async function PageHeader({
       </Row>
 
       {/* DESKTOP PAGE HEADER */}
-      <div className="d-none d-md-block vertical-rhythm">
+      <div className="d-none d-md-block vertical-rhythm py-3">
         {showBack && (
           <div>
             <BackLink>

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -4,7 +4,6 @@ export const contentfulPageIds = {
   about: "01l6lbfvmtbqQHjt7LuUFL",
   "why-email": "6K61ZF3VLMPMi0BjOQ3gjk",
   "ethical-principles": "6UFa3N1g7ytcAxeBCQVyTY",
-  "how-does-it-work": "1BQDLK4P2L1E0DmCwLOrDR",
   vote: "6VgcyUQKmZTr955WYmlhr8",
   "terms-of-service": "1acLWVokjkixcvTh0b3gup",
   "community-posting-guidelines": "fYYpah3B5mppvE7rXY1gY",

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -8,6 +8,7 @@ export const contentIds = {
   vote: "6VgcyUQKmZTr955WYmlhr8",
   "terms-of-service": "1acLWVokjkixcvTh0b3gup",
   "community-posting-guidelines": "fYYpah3B5mppvE7rXY1gY",
+  "what-is-project-protocol": "1Is9QM4ez0YDMYktRuuJZx",
 };
 
 export type ContentfulKey = keyof typeof contentIds;

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -2,6 +2,7 @@ import { createClient } from "contentful";
 
 export const contentfulPageIds = {
   about: "01l6lbfvmtbqQHjt7LuUFL",
+  "the-team": "41UOkLNQQfa6pK2U7Gr46d",
   "why-email": "6K61ZF3VLMPMi0BjOQ3gjk",
   "ethical-principles": "6UFa3N1g7ytcAxeBCQVyTY",
   vote: "6VgcyUQKmZTr955WYmlhr8",

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -1,6 +1,6 @@
 import { createClient } from "contentful";
 
-export const contentIds = {
+export const contentfulPageIds = {
   about: "01l6lbfvmtbqQHjt7LuUFL",
   "why-email": "6K61ZF3VLMPMi0BjOQ3gjk",
   "ethical-principles": "6UFa3N1g7ytcAxeBCQVyTY",
@@ -11,7 +11,7 @@ export const contentIds = {
   "what-is-project-protocol": "1Is9QM4ez0YDMYktRuuJZx",
 };
 
-export type ContentfulKey = keyof typeof contentIds;
+export type ContentfulPageKey = keyof typeof contentfulPageIds;
 
 const client = createClient({
   space: "zwkgwua3qde9",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -176,7 +176,8 @@
     "registerToVote": "Register to vote",
     "resources": "Resources",
     "signUp": "Sign up",
-    "termsOfService": "Terms of Service"
+    "termsOfService": "Terms of Service",
+    "whatIsProjectProtocol": "What is Project Protocol?"
   },
   "password_reset": {
     "emailPlaceholder": "name@example.com",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -168,7 +168,6 @@
     "account": "Account",
     "contact": "Contact us",
     "ethicalPrinciples": "Ethical principles",
-    "howDoesItWork": "How does it work?",
     "localeSwitcher": {
       "selectLanguage": "Select your language"
     },

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -177,6 +177,7 @@
     "resources": "Resources",
     "signUp": "Sign up",
     "termsOfService": "Terms of Service",
+    "theTeam": "The team",
     "whatIsProjectProtocol": "What is Project Protocol?"
   },
   "password_reset": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -162,7 +162,6 @@
     "account": "Cuenta",
     "contact": "Contáctanos",
     "ethicalPrinciples": "Principios éticos",
-    "howDoesItWork": "¿Como funciona?",
     "localeSwitcher": {
       "selectLanguage": "Elige tu idioma"
     },

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -171,6 +171,7 @@
     "resources": "Recursos",
     "signUp": "Registrarse",
     "termsOfService": "Términos de servicio",
+    "theTeam": "El equipo",
     "whatIsProjectProtocol": "¿Qué es Project Protocol?"
   },
   "password_reset": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -170,7 +170,8 @@
     "registerToVote": "Registrarse para votar",
     "resources": "Recursos",
     "signUp": "Registrarse",
-    "termsOfService": "Términos de servicio"
+    "termsOfService": "Términos de servicio",
+    "whatIsProjectProtocol": "¿Qué es Project Protocol?"
   },
   "password_reset": {
     "expiredToken": "El token ha expirado, por favor solicita el restablecimiento de contraseña nuevamente.",


### PR DESCRIPTION
There were some designs in Figma that got missed that add nice cover images to various informational pages, this adds backwards-compatible support for that design (pages without images still render fine), as well as updates what pages are on the site. Fixes PRO-398, PRO-399, PRO-400
## 🛠️ Changes
* Remove how does it work
* Add Team page
* Add ContentfulCoverImage component
* Add optional `hideOnDesktop` functionality to PageHeader
* Adjust some top-level layout padding to give more flexibility to individual pages.

*A note on CSS modules:*

In modern JS apps, it seems to be more idiomatic to let component-specific styles live next to the component itself, so I added a css module directly in the _component folder for ContentCoverImage. Global styles should still live in the `styles/` folder, but just wanted to call out this departure as a pattern to use moving forward. Adhoc styles should still generally be rare.

## TODO
* Fix contentful images in netlify deploy
* Add Partners section to "What is project protocol page" (probably separate branch/ticket)

## 🧪 Testing
Click around preview and check the new Voter, Team, and What is Project Protocol? pages. Also check that pages without images render fine (Terms of Service, Contact us)
<img width="487" alt="Screenshot 2024-09-12 at 3 42 24 PM" src="https://github.com/user-attachments/assets/66915123-895a-4915-a143-29f0fee3f3c7">
<img width="1336" alt="Screenshot 2024-09-12 at 3 42 39 PM" src="https://github.com/user-attachments/assets/78e8f2c5-9bd9-458e-a320-13c594fff470">
