### PR TITLE
Updating popover placement to not run off page

### DIFF
--- a/src/app/(main-layout)/agents/[agentId]/_components/RateAgentForm/index.tsx
+++ b/src/app/(main-layout)/agents/[agentId]/_components/RateAgentForm/index.tsx
@@ -96,7 +96,7 @@ export default function RateAgentForm({ onCancel, agentId }: IRateAgentForm) {
         <p className={isCurrentlyOnParole ? "text-muted" : ""}>
           {t("rate_agent.additionalCommentsHelpText")}
           <OverlayTrigger
-            placement="right"
+            placement="auto"
             overlay={
               <Popover>
                 <Popover.Body>


### PR DESCRIPTION
## 🛠️ Changes

This updates the placement for the popover to not run off the page.

## 🧪 Testing

<img width="367" alt="截屏2024-10-03 上午10 40 54" src="https://github.com/user-attachments/assets/81b7fd06-1fb7-4403-af59-39d2134237ac">

