### PR TITLE
Preventing scroll when filters are added

### DIFF
--- a/src/lib/useSetSearchParams.tsx
+++ b/src/lib/useSetSearchParams.tsx
@@ -31,7 +31,7 @@ export default function useSetSearchParams(): [
           ? `${pathname}?${newParamsString}`
           : pathname;
 
-        router.replace(url);
+        router.replace(url, { scroll: false });
       });
     },
     [pathname, router, searchParams]


### PR DESCRIPTION
## 🛠️ Changes

Sets scroll to false when search params are added for resource filtering.

## 🧪 Testing

Go to resources page, scroll partially down on a mobile view, add and remove filters - the list should change, the number of results changes, but not the scroll position.
