### PR TITLE
[PRO-387] Fix resource cards in firefox

### DIFF
--- a/src/app/(main-layout)/resources/_components/ResourceCard.tsx
+++ b/src/app/(main-layout)/resources/_components/ResourceCard.tsx
@@ -4,9 +4,9 @@ import { Card } from "react-bootstrap";
 import SocialMediaLink from "./SocialMediaLink";
 import TagBadge from "@/components/TagBadge";
 import ResourceVoteControls from "./ResourceVoteControls";
-import Image from "next/image";
 import Link from "next/link";
 
+/* eslint-disable @next/next/no-img-element */
 export default function ResourceCard({ resource }: { resource: Resource }) {
   const t = useTranslations();
 
@@ -46,11 +46,11 @@ export default function ResourceCard({ resource }: { resource: Resource }) {
             className="bg-white d-flex justify-content-center align-items-center rounded rounded-circle border me-2"
             style={{ width: "30px", height: "30px", padding: "6px" }}
           >
-            <Image
+            <img
               src={`https://s2.googleusercontent.com/s2/favicons?domain_url=${url}`}
               width={18}
               height={18}
-              alt={`Favorite icon for ${name}`}
+              alt={""}
             />
           </div>
           <div className="flex flex-column">


### PR DESCRIPTION
## 🛠️ Changes
* Make alt text blank since it doesn't really serve a function here and causes the FF bug

Before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d4419266-30d7-41fa-8fb0-d92c60f1aaa8">

After:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/793dbc71-eda5-4837-9a05-8b74bcacded2">


## 🧪 Testing
Check out the resource page in preview
