### PR TITLE
[Pro-410] UI changes homepage mobile view

### DIFF
--- a/src/app/_components/LandingHeroImage.tsx
+++ b/src/app/_components/LandingHeroImage.tsx
@@ -6,11 +6,10 @@ export default function LandingHeroImage() {
   return (
     <CldImage
       priority
-      src="landing-image_ssfynh"
+      src="landing-page-2_v663w1"
       alt="Palm trees and houses"
       className={styles.topImage}
       sizes="100vw"
-      quality={10}
       fill
     />
   );

--- a/src/app/_components/LandingPageHeader.tsx
+++ b/src/app/_components/LandingPageHeader.tsx
@@ -1,0 +1,50 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Container, Navbar, NavbarBrand } from "react-bootstrap";
+import styles from "@/styles/landing-page.module.scss";
+import LocaleSwitcher from "@/components/LocaleSwitcher";
+
+export default function LandingPageHeader({ locale }: { locale: string }) {
+  return (
+    <Navbar>
+      <Container fluid>
+        <NavbarBrand
+          as={Link}
+          href="/"
+          className="d-flex flex-row align-items-center"
+        >
+          <div className="d-md-none">
+            <Image
+              priority
+              src="/images/icon.svg"
+              width="20"
+              height="20"
+              className="me-2"
+              alt={"Project Protocol logo"}
+            />
+          </div>
+          <div className="d-none d-md-block me-2">
+            <Image
+              priority
+              unoptimized
+              src="/images/icon.svg"
+              width="0"
+              height="0"
+              style={{ width: "25px", height: "auto" }}
+              alt={"Project Protocol logo"}
+            />
+          </div>
+          <span
+            className={
+              "w-100 d-md-inline fw-medium pe-auto text-white " +
+              styles.navbarTitle
+            }
+          >
+            Project Protocol
+          </span>
+        </NavbarBrand>
+        <LocaleSwitcher locale={locale} dark />
+      </Container>
+    </Navbar>
+  );
+}

--- a/src/app/_components/LandingPageHeader.tsx
+++ b/src/app/_components/LandingPageHeader.tsx
@@ -1,50 +1,74 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { Container, Navbar, NavbarBrand } from "react-bootstrap";
 import styles from "@/styles/landing-page.module.scss";
 import LocaleSwitcher from "@/components/LocaleSwitcher";
+import { InView } from "react-intersection-observer";
+import { useState } from "react";
 
-export default function LandingPageHeader({ locale }: { locale: string }) {
+export default function LandingPageHeader({
+  locale,
+  isScrolled,
+}: {
+  locale: string;
+  isScrolled?: boolean;
+}) {
+  const [bg, setBg] = useState("transparent");
   return (
-    <Navbar>
-      <Container fluid>
-        <NavbarBrand
-          as={Link}
-          href="/"
-          className="d-flex flex-row align-items-center"
-        >
-          <div className="d-md-none">
-            <Image
-              priority
-              src="/images/icon.svg"
-              width="20"
-              height="20"
-              className="me-2"
-              alt={"Project Protocol logo"}
-            />
-          </div>
-          <div className="d-none d-md-block me-2">
-            <Image
-              priority
-              unoptimized
-              src="/images/icon.svg"
-              width="0"
-              height="0"
-              style={{ width: "25px", height: "auto" }}
-              alt={"Project Protocol logo"}
-            />
-          </div>
-          <span
-            className={
-              "w-100 d-md-inline fw-medium pe-auto text-white " +
-              styles.navbarTitle
-            }
+    <>
+      <InView
+        as="div"
+        data-testid="observer-target"
+        onChange={(inView) => setBg(inView ? "transparent" : "black")}
+      />
+      <Navbar
+        fixed="top"
+        bg={bg}
+        style={{
+          transition: "background-color 0.5s ease",
+        }}
+      >
+        <Container fluid>
+          <NavbarBrand
+            as={Link}
+            href="/"
+            className="d-flex flex-row align-items-center"
           >
-            Project Protocol
-          </span>
-        </NavbarBrand>
-        <LocaleSwitcher locale={locale} dark />
-      </Container>
-    </Navbar>
+            <div className="d-md-none">
+              <Image
+                priority
+                src="/images/icon.svg"
+                width="20"
+                height="20"
+                className="me-2"
+                alt={"Project Protocol logo"}
+              />
+            </div>
+            <div className="d-none d-md-block me-2">
+              <Image
+                priority
+                unoptimized
+                src="/images/icon.svg"
+                width="0"
+                height="0"
+                style={{ width: "25px", height: "auto" }}
+                alt={"Project Protocol logo"}
+              />
+            </div>
+            <span
+              className={
+                "w-100 d-md-inline fw-medium pe-auto text-white " +
+                styles.navbarTitle
+              }
+            >
+              Project Protocol
+            </span>
+          </NavbarBrand>
+          <LocaleSwitcher locale={locale} dark />
+        </Container>
+      </Navbar>
+    </>
   );
 }

--- a/src/app/_components/LandingPageHeader.tsx
+++ b/src/app/_components/LandingPageHeader.tsx
@@ -8,13 +8,7 @@ import LocaleSwitcher from "@/components/LocaleSwitcher";
 import { InView } from "react-intersection-observer";
 import { useState } from "react";
 
-export default function LandingPageHeader({
-  locale,
-  isScrolled,
-}: {
-  locale: string;
-  isScrolled?: boolean;
-}) {
+export default function LandingPageHeader({ locale }: { locale: string }) {
   const [bg, setBg] = useState("transparent");
   return (
     <>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,8 +21,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   minimumScale: 1,
-  maximumScale: 1,
-  userScalable: false,
+  maximumScale: 5,
   themeColor: [{ media: "(prefers-color-scheme: light)", color: "#f06748" }],
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import landingImage from "@/../public/images/landing-image.jpeg";
 import VideoComponent from "./_components/VideoComponent";
 import { CldImage } from "next-cloudinary";
 import LandingHeroImage from "./_components/LandingHeroImage";
+import LandingPageHeader from "./_components/LandingPageHeader";
 
 const MAX_WIDTH = 720;
 
@@ -27,7 +28,7 @@ function LandingPageSegment({
   classes?: string;
   children: React.ReactNode;
 }) {
-  return <section className={"py-5 " + classes}>{children}</section>;
+  return <section className={"py-3 " + classes}>{children}</section>;
 }
 
 export default async function Page() {
@@ -39,67 +40,42 @@ export default async function Page() {
       <div className={`position-relative w-100 ${styles.topImageContainer}`}>
         <LandingHeroImage />
         <div className={styles.imageOverlay} />
-
-        <Navbar>
-          <Container fluid>
-            <NavbarBrand
-              as={Link}
-              href="/"
-              className="d-flex flex-row align-items-center"
-            >
-              <div className="d-md-none">
-                <Image
-                  priority
-                  src="/images/icon.svg"
-                  width="20"
-                  height="20"
-                  className="me-2"
-                  alt={"Project Protocol logo"}
-                />
-              </div>
-              <div className="d-none d-md-block me-2">
-                <Image
-                  priority
-                  unoptimized
-                  src="/images/icon.svg"
-                  width="0"
-                  height="0"
-                  style={{ width: "25px", height: "auto" }}
-                  alt={"Project Protocol logo"}
-                />
-              </div>
-              <span
-                className={
-                  "w-100 d-md-inline fw-medium pe-auto text-white " +
-                  styles.navbarTitle
-                }
-                style={{ letterSpacing: -0.5 }}
-              >
-                Project Protocol
-              </span>
-            </NavbarBrand>
-            <LocaleSwitcher locale={locale} dark />
-          </Container>
-        </Navbar>
+        <LandingPageHeader locale={locale} />
+        <div
+          className="position-absolute text-white w-100 d-md-none"
+          style={{ bottom: 0 }}
+        >
+          <div className="d-flex flex-column justy-content-center align-items-center p-3">
+            <h1>{t("home.welcomeTitle")}</h1>
+            <p>
+              {t("home.welcomeMessage")}.{" "}
+              <Link href="/content/en-US/about" className="link-white">
+                {t("shared.learnMore")}
+              </Link>
+            </p>
+          </div>
+        </div>
       </div>
-      <div className="content-page">
-        <LandingPageSegment classes="text-center px-4 px-md-0">
+      <div className="content-page mt-0">
+        {/* Desktop Explore Segment */}
+        <LandingPageSegment classes="text-center px-4 px-md-0 d-none d-md-block">
           <div className="m-auto" style={{ maxWidth: 720 }}>
             <h1>{t("home.welcomeTitle")}</h1>
             <p>
               {t("home.welcomeMessage")}.{" "}
               <Link href="/content/en-US/about">{t("shared.learnMore")}</Link>
             </p>
-            <div className="d-none d-md-block">
+            <div>
               <IconLinks locale={locale} classes="py-3 " iconHeight={75} />
             </div>
           </div>
         </LandingPageSegment>
-        <LandingPageSegment classes="bg-white text-center px-4 d-md-none">
-          <h2>{t("home.explore")}</h2>
-          <IconLinks locale={locale} classes="py-3" />
+        {/* Mobile explore segment */}
+        <LandingPageSegment classes="text-center px-4 d-md-none mt-0">
+          <h2 className="mb-3">{t("home.explore")}</h2>
+          <IconLinks locale={locale} />
         </LandingPageSegment>
-        <LandingPageSegment classes="text-center px-3 bg-md-white">
+        <LandingPageSegment classes="text-center px-3 bg-white">
           <h2>{t("home.learnHowToRate")}</h2>
           <div className="h-100 w-100">
             <VideoComponent />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,6 @@
 import { getLocale, getTranslations } from "next-intl/server";
-import Image from "next/image";
 import styles from "@/styles/landing-page.module.scss";
-import Container from "react-bootstrap/Container";
-import Navbar from "react-bootstrap/Navbar";
-import NavbarBrand from "react-bootstrap/NavbarBrand";
 import Link from "next/link";
-import LocaleSwitcher from "@/components/LocaleSwitcher";
 import IconLinks from "./_components/IconLinks";
 import LandingResources from "./_components/LandingResources";
 import { Suspense } from "react";
@@ -13,9 +8,7 @@ import SegmentLoading from "./_components/SegmentLoading";
 import LandingReviews from "./_components/LandingReviews";
 import Footer from "@/components/Footer";
 import "@/styles/content-pages.scss";
-import landingImage from "@/../public/images/landing-image.jpeg";
 import VideoComponent from "./_components/VideoComponent";
-import { CldImage } from "next-cloudinary";
 import LandingHeroImage from "./_components/LandingHeroImage";
 import LandingPageHeader from "./_components/LandingPageHeader";
 
@@ -59,7 +52,7 @@ export default async function Page() {
       <div className="content-page mt-0">
         {/* Desktop Explore Segment */}
         <LandingPageSegment classes="text-center px-4 px-md-0 d-none d-md-block">
-          <div className="m-auto" style={{ maxWidth: 720 }}>
+          <div className="m-auto" style={{ maxWidth: MAX_WIDTH }}>
             <h1>{t("home.welcomeTitle")}</h1>
             <p>
               {t("home.welcomeMessage")}.{" "}
@@ -82,7 +75,10 @@ export default async function Page() {
           </div>
         </LandingPageSegment>
         <LandingPageSegment classes="px-3">
-          <div className="m-auto vertical-rhythm" style={{ maxWidth: 720 }}>
+          <div
+            className="m-auto vertical-rhythm"
+            style={{ maxWidth: MAX_WIDTH }}
+          >
             <div className="d-flex flex-row align-items-center justify-content-between">
               <h2 className="p-0 m-0">{t("home.recentResources")}</h2>
               <Link href="/resources">
@@ -96,7 +92,10 @@ export default async function Page() {
           </div>
         </LandingPageSegment>
         <LandingPageSegment classes="px-3">
-          <div className="m-auto vertical-rhythm" style={{ maxWidth: 720 }}>
+          <div
+            className="m-auto vertical-rhythm"
+            style={{ maxWidth: MAX_WIDTH }}
+          >
             <div className="d-flex flex-row align-items-center justify-content-between">
               <h2 className="p-0 m-0">{t("home.recentReviews")}</h2>
               <Link href="/rate-my-po">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ function LandingPageSegment({
   classes?: string;
   children: React.ReactNode;
 }) {
-  return <section className={"py-3 " + classes}>{children}</section>;
+  return <section className={"py-5 " + classes}>{children}</section>;
 }
 
 export default async function Page() {
@@ -33,15 +33,15 @@ export default async function Page() {
       <div className={`position-relative w-100 ${styles.topImageContainer}`}>
         <LandingHeroImage />
         <div className={styles.imageOverlay} />
-        <LandingPageHeader locale={locale} />
+
         <div
           className="position-absolute text-white w-100 d-md-none"
           style={{ bottom: 0 }}
         >
-          <div className="d-flex flex-column justy-content-center align-items-center p-3">
+          <div className="d-flex flex-column justy-content-center align-items-center pb-1">
             <h1>{t("home.welcomeTitle")}</h1>
-            <p>
-              {t("home.welcomeMessage")}.{" "}
+            <p className="px-5 text-center">
+              {t("home.welcomeMessage")}{" "}
               <Link href="/content/en-US/about" className="link-white">
                 {t("shared.learnMore")}
               </Link>
@@ -49,6 +49,7 @@ export default async function Page() {
           </div>
         </div>
       </div>
+      <LandingPageHeader locale={locale} />
       <div className="content-page mt-0">
         {/* Desktop Explore Segment */}
         <LandingPageSegment classes="text-center px-4 px-md-0 d-none d-md-block">
@@ -64,7 +65,7 @@ export default async function Page() {
           </div>
         </LandingPageSegment>
         {/* Mobile explore segment */}
-        <LandingPageSegment classes="text-center px-4 d-md-none mt-0">
+        <LandingPageSegment classes="text-center px-4 d-md-none">
           <h2 className="mb-3">{t("home.explore")}</h2>
           <IconLinks locale={locale} />
         </LandingPageSegment>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -46,7 +46,7 @@ export default async function Menu() {
               <Image
                 priority
                 unoptimized
-                src={icon.src}
+                src={"/images/icon.svg"}
                 width="0"
                 height="0"
                 className="me-2"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -121,7 +121,7 @@
       "title": "Voting rights restored in California"
     },
     "voteTitle": "Register to vote",
-    "welcomeMessage": "Empowering people on their reentry journey",
+    "welcomeMessage": "We are empowering people in their reentry journey.",
     "welcomeTitle": "Welcome to Project Protocol"
   },
   "login": {

--- a/src/locales/es-MX.json
+++ b/src/locales/es-MX.json
@@ -117,7 +117,7 @@
       "title": "Restauración del derecho de voto en California/Register to Vote"
     },
     "voteTitle": "Registrarse para votar",
-    "welcomeMessage": "Empoderando a las personas en su viaje de reingreso",
+    "welcomeMessage": "Estamos empoderando a las personas en su viaje de reingreso.",
     "welcomeTitle": "Bienvenido a Project Protocol"
   },
   "login": {

--- a/src/styles/landing-page.module.scss
+++ b/src/styles/landing-page.module.scss
@@ -13,11 +13,12 @@
 }
 
 .imageOverlay {
-  background-image: linear-gradient(
-    180deg,
-    rgba(12, 65, 111, 0.3) 0%,
-    rgba(12, 65, 111, 0) 50%
-  );
+  background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 51.94%,
+      rgba(0, 0, 0, 0.65) 78.1%
+    ),
+    linear-gradient(180deg, rgba(12, 65, 111, 0.3) 0%, rgba(12, 65, 111, 0) 50%);
   width: 100%;
   height: 100%;
   position: absolute;
@@ -25,12 +26,25 @@
 
 @include media-breakpoint-up(md) {
   .topImageContainer {
-    height: 500px;
     font-size: 20px;
+  }
+
+  .topImage {
+    object-fit: cover;
+    object-position: 50% 50%;
+  }
+
+  .imageOverlay {
+    background-image: linear-gradient(
+      180deg,
+      rgba(12, 65, 111, 0.5) 0%,
+      rgba(12, 65, 111, 0) 50%
+    );
   }
 
   .navbarTitle {
     font-size: 2rem;
+    letter-spacing: -0.5;
   }
 
   .videoEmbed {

--- a/src/styles/landing-page.module.scss
+++ b/src/styles/landing-page.module.scss
@@ -15,8 +15,8 @@
 .imageOverlay {
   background: linear-gradient(
       180deg,
-      rgba(0, 0, 0, 0) 51.94%,
-      rgba(0, 0, 0, 0.65) 78.1%
+      rgba(0, 0, 0, 0) 30%,
+      rgba(0, 0, 0, 0.8) 78.1%
     ),
     linear-gradient(180deg, rgba(12, 65, 111, 0.3) 0%, rgba(12, 65, 111, 0) 50%);
   width: 100%;


### PR DESCRIPTION
## 🛠️ Changes
[Ticket](https://linear.app/project-protocol/issue/PRO-410/ui-changes-homepage-mobile-view)
* Make top bar sticky on landing page, change colors as user scrolls down.
* Some desktop/mobile layout changes
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/bb6749a4-fa16-45fb-bf3a-8658d8d6499f">
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e5fd736b-5b5d-47dc-95d5-1d0c7ab9bd7a">
<img width="500" alt="image" src="https://github.com/user-attachments/assets/78a08ca4-508b-498f-9c99-e672277de5b7">


## 🧪 Testing
* View mobile and desktop widths on preview and scroll around
