### PR TITLE
Auth restructure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
           version: 9.1.2
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: pnpm

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/src/app/(main-layout)/account/_components/AccountSettings.tsx
+++ b/src/app/(main-layout)/account/_components/AccountSettings.tsx
@@ -13,10 +13,13 @@ import toast from "react-hot-toast";
 import User from "@/types/User";
 import { resendConfirmation } from "@/lib/actions/account";
 import AsyncButton from "@/components/AsyncButton";
+import { useAuth } from "@/components/AuthProvider";
 
-export default function AccountSettings({ user }: { user: User }) {
+export default function AccountSettings() {
   const tAccount = useTranslations("account");
   const tShared = useTranslations("shared");
+  const authInfo = useAuth();
+  const user = authInfo.user as User;
 
   const [resentCode, setResentCode] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/src/app/(main-layout)/account/_components/AccountSettings.tsx
+++ b/src/app/(main-layout)/account/_components/AccountSettings.tsx
@@ -24,7 +24,7 @@ export default function AccountSettings() {
   const router = useRouter();
   const { getOriginalPath } = useOriginalPath();
   const user = auth.user as User;
-  const { refreshUser, setUser } = auth;
+  const { setUser } = auth;
 
   const [resentCode, setResentCode] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -34,8 +34,8 @@ export default function AccountSettings() {
   const handleSignout = async () => {
     await signOut();
     router.replace(getOriginalPath());
-    refreshUser();
     toast.success(tAccount("signOutSuccess"));
+    setUser();
   };
 
   const requestConfirmationCode = async () => {

--- a/src/app/(main-layout)/account/_components/DeleteAccountModal.tsx
+++ b/src/app/(main-layout)/account/_components/DeleteAccountModal.tsx
@@ -4,21 +4,20 @@ import { useTranslations } from "next-intl";
 import PopUp, { IPopUp } from "@/components/PopUp";
 import AsyncButton from "@/components/AsyncButton";
 import { Button } from "react-bootstrap";
-import { deleteAccount, IDeleteAccountFormState } from "@/lib/actions/account";
 import Input from "@/components/Input";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { useCallback } from "react";
 
 interface IDeleteAccountModal {
   onHide: () => void;
-  closeButton?: boolean;
+  handleDelete: SubmitHandler<{ password: string }>;
 }
 
 export default function DeleteAccountModal({
   onHide,
-  closeButton,
+  handleDelete,
   ...popUpProps
 }: IDeleteAccountModal & IPopUp) {
   const t = useTranslations();
@@ -30,22 +29,18 @@ export default function DeleteAccountModal({
         t("shared.requiredField", { field: t("account.delete.password") })
       ),
   });
-  const { register, handleSubmit, getFieldState, formState } =
-    useForm<IDeleteAccountFormState>({
-      mode: "onBlur",
-      defaultValues: {
-        password: "",
-      },
-      resolver: zodResolver(schema),
-    });
-
-  async function onSubmit(data: IDeleteAccountFormState) {
-    await deleteAccount(data);
-    onHide();
-  }
+  const { register, handleSubmit, getFieldState, formState } = useForm<{
+    password: string;
+  }>({
+    mode: "onBlur",
+    defaultValues: {
+      password: "",
+    },
+    resolver: zodResolver(schema),
+  });
 
   const validationProps = useCallback(
-    (fieldName: keyof IDeleteAccountFormState) => {
+    (fieldName: keyof { password: string }) => {
       const { invalid, error } = getFieldState(fieldName, formState);
       return {
         isInvalid: invalid,
@@ -56,13 +51,8 @@ export default function DeleteAccountModal({
   );
 
   return (
-    <PopUp
-      title={t("account.delete.title")}
-      {...popUpProps}
-      closeButton
-      onHide={onHide}
-    >
-      <form className="vertical-rhythm" onSubmit={handleSubmit(onSubmit)}>
+    <PopUp title={t("account.delete.title")} {...popUpProps} onHide={onHide}>
+      <form className="vertical-rhythm" onSubmit={handleSubmit(handleDelete)}>
         <p>{t("account.delete.confirmMessage")}</p>
         <p>{t("account.delete.enterPassword")}</p>
         <Input

--- a/src/app/(main-layout)/account/page.tsx
+++ b/src/app/(main-layout)/account/page.tsx
@@ -3,7 +3,6 @@ import { getTranslations } from "next-intl/server";
 import { getUser } from "@/lib/session";
 import { redirect } from "next/navigation";
 import AccountSettings from "./_components/AccountSettings";
-import { Metadata } from "next";
 import { metaTitle } from "@/lib/metadataUtils";
 
 export async function generateMetadata() {
@@ -12,17 +11,12 @@ export async function generateMetadata() {
 }
 
 export default async function Page() {
-  const user = await getUser();
   const t = await getTranslations();
-
-  if (!user) {
-    redirect("/");
-  }
 
   return (
     <div>
       <PageHeader title={t("account.title")} showBack />
-      <AccountSettings user={user} />
+      <AccountSettings />
     </div>
   );
 }

--- a/src/app/(main-layout)/layout.tsx
+++ b/src/app/(main-layout)/layout.tsx
@@ -1,3 +1,4 @@
+import AuthProvider from "@/components/AuthProvider";
 import Footer from "@/components/Footer";
 import Menu from "@/components/Menu/Menu";
 import MobileTabs from "@/components/Menu/MobileTabs";
@@ -10,12 +11,14 @@ export default async function Layout({
 }) {
   return (
     <main className="d-flex flex-column min-vh-100">
-      <Menu />
-      <Container className="px-3 flex-grow-1" style={{ maxWidth: 630 }}>
-        {children}
-      </Container>
-      <Footer />
-      <MobileTabs />
+      <AuthProvider>
+        <Menu />
+        <Container className="px-3 flex-grow-1" style={{ maxWidth: 630 }}>
+          {children}
+        </Container>
+        <Footer />
+        <MobileTabs />
+      </AuthProvider>
     </main>
   );
 }

--- a/src/app/(main-layout)/rate-my-po/new/page.tsx
+++ b/src/app/(main-layout)/rate-my-po/new/page.tsx
@@ -8,11 +8,6 @@ import AddAgentForm from "./_components/AddAgentForm";
 
 export default async function Page() {
   const t = await getTranslations();
-  const user = await getUser();
-
-  if (!user) {
-    redirect("/");
-  }
 
   return (
     <div>

--- a/src/app/_components/LandingHeroImage.tsx
+++ b/src/app/_components/LandingHeroImage.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import styles from "@/styles/landing-page.module.scss";
 import { CldImage } from "next-cloudinary";
 

--- a/src/app/_components/LandingHeroImage.tsx
+++ b/src/app/_components/LandingHeroImage.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import styles from "@/styles/landing-page.module.scss";
 import { CldImage } from "next-cloudinary";
 

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,7 @@
+import { getUser } from "@/lib/session";
+
+export async function GET() {
+  const user = await getUser();
+
+  return Response.json(user || null);
+}

--- a/src/app/auth/_components/AuthLayout.tsx
+++ b/src/app/auth/_components/AuthLayout.tsx
@@ -3,7 +3,7 @@ import { Container } from "react-bootstrap";
 import LocaleSwitcher from "@/components/LocaleSwitcher";
 import AuthCloseButton from "./AuthCloseButton";
 
-export default async function AuthLayout({
+export default function AuthLayout({
   locale,
   pageTitle,
   children,

--- a/src/app/auth/confirmations/_components/ConfirmEmail.tsx
+++ b/src/app/auth/confirmations/_components/ConfirmEmail.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useAuth } from "@/components/AuthProvider";
 import { useOriginalPath } from "@/components/OriginalPathProvider";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 
-export default function ConfirmEmail({ email }: { email: string }) {
+export default function ConfirmEmail() {
   const t = useTranslations();
+  const { user } = useAuth();
   const { getOriginalPath } = useOriginalPath();
 
   return (
@@ -13,7 +15,7 @@ export default function ConfirmEmail({ email }: { email: string }) {
       <div className="text-center mb-3">{t("login.confirmSignupTitle")}</div>
       <p>
         {t.rich("login.loginConfirmSignupDetail1", {
-          email: email,
+          email: user!.email,
           b: (chunks) => <b>{chunks}</b>,
         })}
       </p>

--- a/src/app/auth/confirmations/page.tsx
+++ b/src/app/auth/confirmations/page.tsx
@@ -1,14 +1,5 @@
 import ConfirmEmail from "@/app/auth/confirmations/_components/ConfirmEmail";
-import { getUser } from "@/lib/session";
-import { redirect } from "next/navigation";
 
 export default async function Page() {
-  const user = await getUser();
-  const email = user?.email;
-
-  if (!email) {
-    return redirect("/");
-  }
-
-  return <ConfirmEmail email={email} />;
+  return <ConfirmEmail />;
 }

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -1,12 +1,5 @@
 import ForgotPasswordForm from "./_components/ForgotPasswordForm";
-import { getUser } from "@/lib/session";
-import { redirect } from "next/navigation";
 
 export default async function Page() {
-  const user = await getUser();
-  if (user) {
-    redirect("/");
-  }
-
   return <ForgotPasswordForm />;
 }

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,3 +1,4 @@
+import AuthProvider from "@/components/AuthProvider";
 import AuthLayout from "./_components/AuthLayout";
 import { getLocale } from "next-intl/server";
 import { getTranslations } from "next-intl/server";
@@ -11,7 +12,7 @@ export default async function Layout({
   const t = await getTranslations();
   return (
     <AuthLayout locale={locale} pageTitle={t("login.loginTitle")}>
-      {children}
+      <AuthProvider>{children}</AuthProvider>
     </AuthLayout>
   );
 }

--- a/src/app/auth/login/_components/LoginForm.tsx
+++ b/src/app/auth/login/_components/LoginForm.tsx
@@ -11,10 +11,12 @@ import { useCallback, useState } from "react";
 import Link from "next/link";
 import { useOriginalPath } from "@/components/OriginalPathProvider";
 import toast from "react-hot-toast";
+import { useAuth } from "@/components/AuthProvider";
+import { useRouter } from "next/navigation";
 
 export default function LoginForm() {
   const t = useTranslations();
-  const { redirectToOriginalPath } = useOriginalPath();
+  const { getOriginalPath } = useOriginalPath();
   const [isLoading, setIsLoading] = useState(false);
 
   const schema = z.object({
@@ -39,13 +41,14 @@ export default function LoginForm() {
 
   async function onSubmit(data: ILoginFormState) {
     setIsLoading(true);
-    const err = await login(data);
+    const redirectTo = getOriginalPath();
+    const err = await login(data, redirectTo);
+
     if (err) {
       toast.error(t("login.loginFieldsError"));
       setIsLoading(false);
     } else {
       toast.success(t("login.success"));
-      redirectToOriginalPath();
     }
   }
 

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,12 +1,5 @@
 import LoginForm from "./_components/LoginForm";
-import { getUser } from "@/lib/session";
-import { redirect } from "next/navigation";
 
 export default async function Page() {
-  const user = await getUser();
-  if (user) {
-    redirect("/");
-  }
-
   return <LoginForm />;
 }

--- a/src/app/auth/signup/_components/SignupForm.tsx
+++ b/src/app/auth/signup/_components/SignupForm.tsx
@@ -12,10 +12,12 @@ import AsyncButton from "../../../../components/AsyncButton";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import toast from "react-hot-toast";
+import { useAuth } from "@/components/AuthProvider";
 
 export default function SignupForm() {
   const t = useTranslations();
   const [loading, setLoading] = useState(false);
+  const { setUser } = useAuth();
   const schema = z.object({
     signUpEmail: z
       .string()
@@ -39,8 +41,9 @@ export default function SignupForm() {
 
   async function onSubmit(data: ISignupFormState) {
     setLoading(true);
-    const { error } = await signUp(data);
+    const { user, error } = await signUp(data);
     if (!error) {
+      setUser(user);
       router.replace(`/auth/confirmations`);
     } else {
       setLoading(false);

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,12 +1,5 @@
 import SignupForm from "@/app/auth/signup/_components/SignupForm";
-import { getUser } from "@/lib/session";
-import { redirect } from "next/navigation";
 
 export default async function Page() {
-  const user = await getUser();
-  if (user) {
-    redirect("/");
-  }
-
   return <SignupForm />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,6 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const user = await getUser();
   const locale = await getLocale();
   const messages = await getMessages();
 
@@ -59,9 +58,7 @@ export default async function RootLayout({
         <ProgressBarWrapperNoSSR />
         <NextIntlClientProvider messages={messages}>
           <NotificationArea />
-          <OriginalPathProvider>
-            <AuthProvider user={user}>{children}</AuthProvider>
-          </OriginalPathProvider>
+          <OriginalPathProvider>{children}</OriginalPathProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import User from "@/types/User";
 
 type AuthProviderValue = {
@@ -13,11 +13,11 @@ const AuthContext = createContext<AuthProviderValue | undefined>(undefined);
 
 export default function AuthProvider({
   children,
-  user,
 }: {
   children: React.ReactNode;
-  user?: User;
 }) {
+  const [user, setUser] = useState<User>();
+  const [firstLoad, setFirstLoad] = useState(true);
   const isSignedIn = useMemo(() => !!user, [user]);
   const [policyAcknowledged, setPolicyAcknowledged] = useState(
     user?.isPolicyAcknowledged || false
@@ -31,6 +31,19 @@ export default function AuthProvider({
     return policyAcknowledged;
   }
 
+  useEffect(() => {
+    if (firstLoad && !user) {
+      fetch("/api/user")
+        .then((res) => res.json())
+        .then((data) => {
+          setUser(data);
+        })
+        .finally(() => {
+          setFirstLoad(false);
+        });
+    }
+  }, [firstLoad, user]);
+
   const value = {
     user,
     isSignedIn,
@@ -38,7 +51,11 @@ export default function AuthProvider({
     updateAcknowledgePolicy,
   };
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={value}>
+      {!firstLoad && children}
+    </AuthContext.Provider>
+  );
 }
 
 export function useAuth() {

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -4,6 +4,7 @@ import User from "@/types/User";
 
 type AuthProviderValue = {
   user?: User;
+  setUser: (user: User) => void;
   isSignedIn: boolean;
   isPolicyAcknowledged: () => boolean;
   updateAcknowledgePolicy: () => void;
@@ -46,6 +47,7 @@ export default function AuthProvider({
 
   const value = {
     user,
+    setUser,
     isSignedIn,
     isPolicyAcknowledged,
     updateAcknowledgePolicy,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,22 +1,23 @@
+"use client";
 import Navbar from "react-bootstrap/Navbar";
 import NavbarBrand from "react-bootstrap/NavbarBrand";
 import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
-import NavLink from "react-bootstrap/NavLink";
 import NavItem from "react-bootstrap/NavItem";
 import Image from "next/image";
 import Link from "next/link";
-import { getLocale, getTranslations } from "next-intl/server";
 import LocaleSwitcher from "../LocaleSwitcher";
-import { getUser } from "@/lib/session";
 import MenuLink from "./MenuLink";
+import { useLocale, useTranslations } from "next-intl";
+import { useAuth } from "../AuthProvider";
 
 export const MENU_MAX_WIDTH = 1048;
 
-export default async function Menu() {
-  const t = await getTranslations();
-  const user = await getUser();
-  const locale = await getLocale();
+export default function Menu() {
+  const { user } = useAuth();
+  const tHome = useTranslations("home");
+  const tNavigation = useTranslations("navigation");
+  const locale = useLocale();
 
   return (
     <Navbar className="bg-black flex-column py-0 overflow-hidden" sticky="top">
@@ -56,11 +57,11 @@ export default async function Menu() {
           </NavbarBrand>
           <Nav className="fs-4 d-none d-md-flex align-items-center gap-2 fw-semibold">
             <MenuLink as={Link} className="m-0" href="/" exact>
-              {t("home.title")}
+              {tHome("title")}
             </MenuLink>
-            <MenuLink href="/rate-my-po">{t("navigation.rateMyPo")}</MenuLink>
+            <MenuLink href="/rate-my-po">{tNavigation("rateMyPo")}</MenuLink>
             <MenuLink className="m-0" href="/resources">
-              {t("navigation.resources")}
+              {tNavigation("resources")}
             </MenuLink>
             {user ? (
               <MenuLink className="m-0" href="/account" title="Account">
@@ -79,7 +80,7 @@ export default async function Menu() {
                   href="/auth/signup"
                   scroll={false}
                 >
-                  {t("navigation.signUp")}
+                  {tNavigation("signUp")}
                 </Link>
               </NavItem>
             )}

--- a/src/components/OriginalPathProvider.tsx
+++ b/src/components/OriginalPathProvider.tsx
@@ -13,7 +13,7 @@ export const OriginalPathContext = createContext<
   OriginalPathProviderValue | undefined
 >(undefined);
 
-const redirectRoutes = ["/auth"];
+const redirectRoutes = ["/auth", "/account"];
 
 function isRedirectRoute(path: string): boolean {
   for (const n of redirectRoutes) {

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,8 +1,11 @@
+"use client";
 import { Col, Row } from "react-bootstrap";
 import { getUser } from "@/lib/session";
 import { getTranslations } from "next-intl/server";
 import BackLink from "./BackLink";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useAuth } from "./AuthProvider";
 
 interface IPageHeader {
   title: string | JSX.Element;
@@ -12,13 +15,14 @@ interface IPageHeader {
   hideOnDesktop?: boolean;
 }
 
-export default async function PageHeader({
+export default function PageHeader({
   title,
   showBack = false,
   hideOnDesktop,
 }: IPageHeader) {
-  const user = await getUser();
-  const t = await getTranslations();
+  const { user } = useAuth();
+  const t = useTranslations();
+
   return (
     <div className={`py-3 ${hideOnDesktop ? "d-md-none" : ""}`}>
       {/* MOBILE PAGE HEADER */}

--- a/src/components/notifications/NotificationArea.tsx
+++ b/src/components/notifications/NotificationArea.tsx
@@ -1,11 +1,7 @@
 import { Toaster } from "react-hot-toast";
-import FlashMessages from "./FlashMessages";
-import { getFlashMessages } from "@/lib/flash-messages";
 
 // Options: https://react-hot-toast.com/docs/toaster
 export default function NotificationArea() {
-  const messages = getFlashMessages();
-
   return (
     <>
       <Toaster
@@ -17,7 +13,6 @@ export default function NotificationArea() {
           },
         }}
       />
-      <FlashMessages messages={messages} />
     </>
   );
 }

--- a/src/lib/actions/account.ts
+++ b/src/lib/actions/account.ts
@@ -2,7 +2,7 @@
 
 import Api from "../api";
 import { redirect } from "next/navigation";
-import { destroySession, getSession } from "../session";
+import { signOut, getSession } from "../session";
 import { getTranslations } from "next-intl/server";
 import { flashError, flashSuccess } from "../flash-messages";
 import { snakeCaseKeys } from "../transformKeys";
@@ -128,11 +128,13 @@ export async function changePassword({
   return { error } as ChangePasswordResponse;
 }
 
-export interface IDeleteAccountFormState {
+export async function deleteAccount({
+  password,
+}: {
   password: string;
-}
-
-export async function deleteAccount({ password }: IDeleteAccountFormState) {
+}): Promise<{
+  error?: string;
+}> {
   const session = await getSession();
   const t = await getTranslations();
 
@@ -141,14 +143,14 @@ export async function deleteAccount({ password }: IDeleteAccountFormState) {
   );
 
   if (!response.ok) {
-    flashError(t("account.delete.error"));
     return {
       error: t("account.delete.error"),
     };
   }
 
-  flashSuccess(t("account.delete.success"));
-  await destroySession();
+  await signOut();
+
+  return {};
 }
 
 export async function acknowledgePolicy() {

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -60,7 +60,6 @@ export async function signUp({ signUpEmail, password }: ISignupFormState) {
   const data = await response.json();
 
   if (!response.ok) {
-    flashError(t("shared.genericError"));
     return {
       error: data.error,
     };
@@ -68,7 +67,6 @@ export async function signUp({ signUpEmail, password }: ISignupFormState) {
 
   const apiToken = response.headers.get("authorization");
   if (!apiToken) {
-    flashError(t("shared.genericError"));
     return {
       error: "Unable to retrieve API token",
     };
@@ -78,9 +76,7 @@ export async function signUp({ signUpEmail, password }: ISignupFormState) {
 
   await signIn(data.user, apiToken, cookies());
 
-  flashSuccess(t("login.register.success"));
-
-  return { email, isConfirmed };
+  return { user: data.user, error: null };
 }
 
 /**
@@ -98,7 +94,6 @@ export async function confirmAccount(token: string) {
   });
 
   if (!response.ok) {
-    flashError(t("shared.genericError"));
     throw new Error("Confirm account: something went wrong");
   }
 

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -3,7 +3,7 @@
 import { signIn } from "../session";
 import { flashError, flashSuccess } from "../flash-messages";
 import { getTranslations } from "next-intl/server";
-import { redirect } from "next/navigation";
+import { redirect, RedirectType } from "next/navigation";
 import Api from "../api";
 import { cookies } from "next/headers";
 
@@ -12,7 +12,10 @@ export interface ILoginFormState {
   password: string;
 }
 
-export async function login({ loginEmail, password }: ILoginFormState) {
+export async function login(
+  { loginEmail, password }: ILoginFormState,
+  redirectTo = "/"
+) {
   const t = await getTranslations();
 
   const response = await new Api().post("/auth/sign_in", {
@@ -35,8 +38,8 @@ export async function login({ loginEmail, password }: ILoginFormState) {
       error: "Unable to retrieve API token",
     };
   }
-
   await signIn(data.user, apiToken, cookies());
+  redirect(redirectTo, RedirectType.replace);
 }
 
 export interface ISignupFormState {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -94,7 +94,6 @@ export async function signIn(
 /**
  * Signs the user out by deleting the session cookie.
  */
-export async function destroySession() {
+export async function signOut() {
   cookies().delete("session");
-  redirect("/", RedirectType.replace);
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -7,6 +7,7 @@ import User from "@/types/User";
 import Api from "./api";
 import { getTranslations } from "next-intl/server";
 import { ResponseCookies } from "next/dist/compiled/@edge-runtime/cookies";
+import { redirect, RedirectType } from "next/navigation";
 
 type Session = {
   user: User;
@@ -94,6 +95,6 @@ export async function signIn(
  * Signs the user out by deleting the session cookie.
  */
 export async function destroySession() {
-  const t = await getTranslations();
   cookies().delete("session");
+  redirect("/", RedirectType.replace);
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -5,9 +5,7 @@ import { decrypt, encrypt, freshExpiryDate, timeToExpiryInMs } from "./jwt";
 import { NextRequest, NextResponse } from "next/server";
 import User from "@/types/User";
 import Api from "./api";
-import { getTranslations } from "next-intl/server";
 import { ResponseCookies } from "next/dist/compiled/@edge-runtime/cookies";
-import { redirect, RedirectType } from "next/navigation";
 
 type Session = {
   user: User;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,31 @@
-import { NextRequest } from "next/server";
-import { updateSession } from "./lib/session";
+import { NextRequest, NextResponse } from "next/server";
+import { getUser } from "./lib/session";
+
+const AUTH_REDIRECTS = [
+  "/auth/confirmations",
+  "/auth/login",
+  "/auth/signup",
+  "/auth/forgot-password",
+];
+
+const AUTH_REQUIRED = ["/account", "/rate-my-po/new"];
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request);
+  if (AUTH_REQUIRED.includes(request.nextUrl.pathname)) {
+    const user = await getUser();
+    if (!user) {
+      return NextResponse.redirect(new URL("/", request.url));
+    }
+  }
+
+  if (AUTH_REDIRECTS.includes(request.nextUrl.pathname)) {
+    const user = await getUser();
+    if (user) {
+      return NextResponse.redirect(new URL("/", request.url));
+    }
+  }
 }
+
+export const config = {
+  matcher: "/((?!api|_next/static|favicon.ico|images).*)",
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUser } from "./lib/session";
 
-const AUTH_REDIRECTS = [
-  "/auth/confirmations",
-  "/auth/login",
-  "/auth/signup",
-  "/auth/forgot-password",
-];
+const AUTH_REDIRECTS = ["/auth/login", "/auth/signup", "/auth/forgot-password"];
 
 const AUTH_REQUIRED = ["/account", "/rate-my-po/new"];
 

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from "@playwright/test";
+import { randomUUID } from "crypto";
 
 const USER_EMAIL = "e2e-test-user@user.com";
 const USER_PW = "P@ssword";
-
 test("allows user to log in and return to original page", async ({ page }) => {
   // Go to Voting rights article before accessing log in screen
   await page.goto("/content/en-US/vote");
@@ -36,4 +36,48 @@ test("user is redirected to original page after password reset", async ({
   await expect(page).toHaveURL(originalPath);
 });
 
-// Test
+// Test Registration and redirect to original page
+/**
+ * 1. Sign up user - maybe special name to prevent emails, and hardcode confirmation token
+ * 2. Assert confirmation page
+ * 3. Assert flash messages
+ * 4. Assert redirect to original page
+ * 5. Access account page
+ * 6. Assert ability to delete account
+ * 7. Assert redirect to original page
+ * 8. Assert flash messages
+ */
+test("account creation and deletion", async ({ page }) => {
+  const { email, password } = generateRandomEmailAndPassword();
+  const originalPath = "/rate-my-po";
+  await page.goto(originalPath);
+  await page.getByRole("link", { name: "Sign up" }).click();
+  await page.locator("input#signup-email").fill(email);
+  await page.locator("input#signup-password").fill(password);
+  await page.locator("button[type='submit']").click();
+
+  await expect(page).toHaveURL("/auth/confirmations");
+  await page.getByRole("link", { name: "OK" }).click();
+
+  await expect(page).toHaveURL(originalPath);
+
+  await page.getByTitle("Account").locator("visible=true").click();
+  await expect(page).toHaveURL("/account");
+
+  await page.getByRole("button", { name: "Delete" }).click();
+  await page.locator("input#Password").fill(password);
+  await page.locator("button[type='submit']").click();
+
+  await expect(page).toHaveURL(originalPath);
+  await expect(page.getByText("Account successfully deleted")).toBeVisible();
+
+  // Check that the navbar refreshed to logged out state
+  await expect(page.locator('a[title="Account"]')).not.toBeVisible();
+});
+
+function generateRandomEmailAndPassword() {
+  return {
+    email: `e2e-delete-me-${randomUUID()}@user.com`,
+    password: randomUUID(),
+  };
+}

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -5,7 +5,8 @@ const USER_EMAIL = "e2e-test-user@user.com";
 const USER_PW = "P@ssword";
 test("allows user to log in and return to original page", async ({ page }) => {
   // Go to Voting rights article before accessing log in screen
-  await page.goto("/content/en-US/vote");
+  const originalPath = "/rate-my-po";
+  await page.goto(originalPath);
   await page.getByRole("link", { name: "Sign up" }).click();
   await page.getByRole("link", { name: "Log in" }).click();
 
@@ -17,7 +18,7 @@ test("allows user to log in and return to original page", async ({ page }) => {
   await expect(page.getByText("Sign in successful!")).toBeVisible();
 
   // Check that user is redirected to voting article after login
-  await expect(page).toHaveURL("/content/en-US/vote");
+  await expect(page).toHaveURL(originalPath);
 });
 
 // Test forgot password and redirect to original page
@@ -27,7 +28,6 @@ test("user is redirected to original page after password reset", async ({
   const originalPath = "/content/en-US/contact-us";
   await page.goto(originalPath);
   await page.getByRole("link", { name: "Sign up" }).click();
-  await page.getByRole("link", { name: "Log in" }).click();
   await page.getByRole("link", { name: "Log in" }).click();
   await page.getByRole("link", { name: "Forgot password?" }).click();
 

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -7,15 +7,24 @@ test("has title", async ({ page }) => {
 
 test("top three links to appropriate pages", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("link", { name: "Icon for Search resources" }).click();
+  await page
+    .getByRole("link", { name: "Icon for Search resources" })
+    .locator("visible=true")
+    .click();
   await expect(page).toHaveURL(/resources/);
 
   await page.goBack();
-  await page.getByRole("link", { name: "Icon for Rate my PO" }).click();
+  await page
+    .getByRole("link", { name: "Icon for Rate my PO" })
+    .locator("visible=true")
+    .click();
   await expect(page).toHaveURL(/rate-my-po/);
 
   await page.goBack();
-  await page.getByRole("link", { name: "Icon for Register to vote" }).click();
+  await page
+    .getByRole("link", { name: "Icon for Register to vote" })
+    .locator("visible=true")
+    .click();
   await expect(page).toHaveURL(/content\/en-US\/vote/);
 });
 


### PR DESCRIPTION
## 📖 Background
Auth and `next-intl` are the two aspects of the current Nextjs app that rely on checking cookies on nearly every page. Interacting with cookies and headers forces a page to be dynamically re-rendered on every request, rather than statically generating html at build-time.

This branch addresses the Auth portion of this, leaving only a few calls to `getSession` in Server components which rely on dynamic data (rate-my-po/:id) and would not be candidates for static page generation anyway. All uses of `getUser` in react components have been removed.

## 🛠️ Changes
* Convert all UI that changes based on Auth state to client components. These now use `useAuth` from the AuthProvider to access authentication/user state.
* Update AuthProvider to send a request to `GET /api/user` on load and store that value.
* Remove cookie-based flash messages (also was causing app-wide cookie reads)
* Add middleware to handle authentication-based redirects, both for signed in redirects (most of the auth/ routes), and for protecting auth-only pages (e.g. /account).
* Update the `login` server action to accept a redirect URL.

## 🧪 Testing
* Try logging in and various auth flows
* Check the account settings page
* Make sure redirects happen when expected
* Check that you can't access /auth/login when signed in
* Check that you can't access /account when signed out
