### PR TITLE
[PRO-421] Handle unconfirmed user for add an agent card

### DIFF
--- a/src/app/[locale]/(app)/rate-my-po/_components/AddAgentCard.tsx
+++ b/src/app/[locale]/(app)/rate-my-po/_components/AddAgentCard.tsx
@@ -1,38 +1,61 @@
+"use client";
+
 import Card from "react-bootstrap/Card";
 import { useTranslations } from "next-intl";
 import { useAuth } from "@/components/AuthProvider";
+import ConfirmationModal from "../agents/[agentId]/_components/ConfirmationModal";
+import { useState } from "react";
+import { Button } from "react-bootstrap";
+import { useRouter } from "next/navigation";
 import { Link } from "@/i18n/routing";
 
 export default function AddAgentCard() {
   const t = useTranslations();
   const { user } = useAuth();
+  const router = useRouter();
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+
+  const addAgentButtonOnClick = () => {
+    user?.isConfirmed
+      ? router.push("/rate-my-po/agents/new")
+      : setShowConfirmationModal(true);
+  };
+
   return (
-    <Card border="0" className="mb-3">
-      <Card.Body className="p-4 text-center vertical-rhythm">
-        <h3>{t("rate_my_po.noResults", { ns: "rate_my_po" })}</h3>
-        {user ? (
-          <Link
-            href="/rate-my-po/agents/new"
-            aria-label={t("agent.addAgent")}
-            className="w-75 btn btn-lg btn-primary"
-          >
-            {t("agent.addAgent")}
-          </Link>
-        ) : (
-          <>
-            <Link
-              href="/auth/signup"
-              aria-label={t("agent.signUpToAddAgent")}
-              className="btn btn-lg btn-primary w-75 mb-3"
+    <>
+      <Card border="0" className="mb-3">
+        <Card.Body className="p-4 text-center vertical-rhythm">
+          <h3>{t("rate_my_po.noResults", { ns: "rate_my_po" })}</h3>
+          {user ? (
+            <Button
+              onClick={addAgentButtonOnClick}
+              aria-label={t("agent.addAgent")}
+              className="w-75 btn btn-lg btn-primary"
             >
-              {t("agent.signUpToAddAgent")}
-            </Link>
-            <Link href="/auth/login" className="d-block">
-              {t("shared.orLogIn")}
-            </Link>
-          </>
-        )}
-      </Card.Body>
-    </Card>
+              {t("agent.addAgent")}
+            </Button>
+          ) : (
+            <>
+              <Link
+                href="/auth/sign-up"
+                aria-label={t("agent.signUpToAddAgent")}
+                className="btn btn-lg btn-primary w-75 mb-3"
+              >
+                {t("agent.signUpToAddAgent")}
+              </Link>
+              <Link href="/auth/login" className="d-block">
+                {t("shared.orLogIn")}
+              </Link>
+            </>
+          )}
+        </Card.Body>
+      </Card>
+      <ConfirmationModal
+        show={showConfirmationModal}
+        onHide={() => setShowConfirmationModal(false)}
+        user={user}
+        title={t("agent.confirmAccountToAddAgent")}
+      />
+    </>
   );
 }

--- a/src/app/[locale]/(app)/rate-my-po/_components/AddAgentCard.tsx
+++ b/src/app/[locale]/(app)/rate-my-po/_components/AddAgentCard.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/components/AuthProvider";
 import ConfirmationModal from "../agents/[agentId]/_components/ConfirmationModal";
 import { useState } from "react";
 import { Button } from "react-bootstrap";
-import { useRouter } from "next/navigation";
+import { useRouter } from "@/i18n/routing";
 import { Link } from "@/i18n/routing";
 
 export default function AddAgentCard() {

--- a/src/app/[locale]/(app)/rate-my-po/agents/[agentId]/_components/ConfirmationModal.tsx
+++ b/src/app/[locale]/(app)/rate-my-po/agents/[agentId]/_components/ConfirmationModal.tsx
@@ -11,10 +11,12 @@ import toast from "react-hot-toast";
 interface IConfirmationModal extends IPopUp {
   user?: User;
   resentCodeAt?: Date;
+  title?: string;
 }
 
 export default function ConfirmationModal({
   user,
+  title,
   ...popUpProps
 }: IConfirmationModal) {
   const [resentCodeAt, setResentCodeAt] = useState<Date>();
@@ -29,7 +31,10 @@ export default function ConfirmationModal({
   };
 
   return (
-    <PopUp title={t("home.confirmationModal.title")} {...popUpProps}>
+    <PopUp
+      title={title ? title : t("home.confirmationModal.title")}
+      {...popUpProps}
+    >
       {user && (
         <>
           <p>


### PR DESCRIPTION
## 🛠️ Changes

Updates `AddAgentCard.tsx` to check if user is confirmed: if so, then user is taken to add an agent page; if not, then confirmation modal pops up.

## 🧪 Testing

- Sign up a new user and attempt to add an agent, note a confirmation modal will pop up
- Login a confirmed user and attempt to add an agent, note you'll be able to now

***NOTES:***

Current `ConfirmationModal.tsx` had a static title that doesn't match current context ("Confirm your account to rate agents"). This may be a good opportunity to genericize the confirmation title and allow optional, more specific titles to be passed in different contexts (who knows what we'll be requiring confirmation for in the future?). 

As is, the base title is for rating agents and there is now an option to pass in a custom title if appropriate. This may be perfectly fine too if we think the most frequent use case of confirmation is for rating agents (which I'm inclined to think).