### PR TITLE
Adding social media links to the Footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -34,21 +34,51 @@ export default async function Footer() {
     },
   ];
 
+  const socialMediaLinks = [
+    {
+      url: "https://www.instagram.com/project.protocol",
+      icon: "instagram",
+    },
+    {
+      url: "https://www.linkedin.com/company/projectprotocol/",
+      icon: "linkedin",
+    },
+    {
+      url: "https://www.tiktok.com/@projectprotocol",
+      icon: "tiktok",
+    },
+    {
+      url: "https://www.facebook.com/projectprotocol/",
+      icon: "facebook",
+    },
+  ];
+
   return (
-    <div
-      className="bg-dark text-center mt-auto py-md-4 pt-4"
-      style={{ paddingBottom: "100px" }}
-    >
-      {links.map(({ label, url, target }) => (
-        <Link
-          key={`footer-link-${label}`}
-          className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
-          href={url}
-          target={target || "_self"}
-        >
-          {label}
-        </Link>
-      ))}
-    </div>
+    <>
+      <div className="bg-dark text-center mt-auto py-md-4 pt-4">
+        {links.map(({ label, url, target }) => (
+          <Link
+            key={`footer-link-${label}`}
+            className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
+            href={url}
+            target={target || "_self"}
+          >
+            {label}
+          </Link>
+        ))}
+        <span className="d-flex flex-wrap justify-content-center">
+          {socialMediaLinks.map(({ url, icon }) => (
+            <a
+              key={`social-link-${icon}`}
+              href={url}
+              target="_blank"
+              className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
+            >
+              <i className={`bi bi-${icon}`}></i>
+            </a>
+          ))}
+        </span>
+      </div>
+    </>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -40,22 +40,22 @@ export default async function Footer() {
       icon: "instagram",
     },
     {
-      url: "https://www.linkedin.com/company/projectprotocol/",
-      icon: "linkedin",
+      url: "https://www.facebook.com/projectprotocol/",
+      icon: "facebook",
     },
     {
       url: "https://www.tiktok.com/@projectprotocol",
       icon: "tiktok",
     },
     {
-      url: "https://www.facebook.com/projectprotocol/",
-      icon: "facebook",
+      url: "https://www.linkedin.com/company/projectprotocol/",
+      icon: "linkedin",
     },
   ];
 
   return (
     <>
-      <div className="bg-dark text-center mt-auto py-md-4 pt-4">
+      <div className="bg-dark text-center mt-auto py-md-4 pt-4 pb-5">
         {links.map(({ label, url, target }) => (
           <Link
             key={`footer-link-${label}`}
@@ -74,7 +74,7 @@ export default async function Footer() {
               target="_blank"
               className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
             >
-              <i className={`bi bi-${icon}`}></i>
+              <i className={`bi bi-${icon} h1`}></i>
             </a>
           ))}
         </span>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -54,31 +54,29 @@ export default async function Footer() {
   ];
 
   return (
-    <>
-      <div className="bg-dark text-center mt-auto py-md-4 pt-4 pb-5">
-        {links.map(({ label, url, target }) => (
-          <Link
-            key={`footer-link-${label}`}
-            className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
+    <div className="bg-dark text-center mt-auto py-md-4 pt-4 pb-5 mb-5 mb-md-0">
+      {links.map(({ label, url, target }) => (
+        <Link
+          key={`footer-link-${label}`}
+          className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
+          href={url}
+          target={target || "_self"}
+        >
+          {label}
+        </Link>
+      ))}
+      <span className="d-flex flex-wrap justify-content-center my-3">
+        {socialMediaLinks.map(({ url, icon }) => (
+          <a
+            key={`social-link-${icon}`}
             href={url}
-            target={target || "_self"}
+            target="_blank"
+            className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
           >
-            {label}
-          </Link>
+            <i className={`bi bi-${icon} fs-1`}></i>
+          </a>
         ))}
-        <span className="d-flex flex-wrap justify-content-center">
-          {socialMediaLinks.map(({ url, icon }) => (
-            <a
-              key={`social-link-${icon}`}
-              href={url}
-              target="_blank"
-              className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
-            >
-              <i className={`bi bi-${icon} h1`}></i>
-            </a>
-          ))}
-        </span>
-      </div>
-    </>
+      </span>
+    </div>
   );
 }


### PR DESCRIPTION
## 🛠️ Changes

This adds social media links to the footer and sets them to wrap / be inline at mobile screens. 

Related to https://linear.app/project-protocol/issue/PRO-414/[footer-ui]-add-social-media-links

## 🧪 Testing

<img width="856" alt="Screenshot 2024-10-30 at 1 59 52 PM" src="https://github.com/user-attachments/assets/8cfc8314-d9d8-489c-a952-8ec9e068063e">
<img width="394" alt="Screenshot 2024-10-30 at 2 00 12 PM" src="https://github.com/user-attachments/assets/8ad131ad-6ef8-42b1-9b91-7bc0c08f5115">

