### PR TITLE
Bump next intl to 3.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash-es": "^4.17.21",
     "next": "^14.2.17",
     "next-cloudinary": "^6.12.0",
-    "next-intl": "^3.21.1",
+    "next-intl": "^3.25.0",
     "next-pwa": "^5.6.0",
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^6.12.0
         version: 6.12.0(next@14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6))(react@18.3.1)
       next-intl:
-        specifier: ^3.21.1
-        version: 3.21.1(next@14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6))(react@18.3.1)
+        specifier: ^3.25.0
+        version: 3.25.0(next@14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6))(react@18.3.1)
       next-pwa:
         specifier: ^5.6.0
         version: 5.6.0(@babel/core@7.25.2)(next@14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6))(webpack@5.93.0)
@@ -766,20 +766,23 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@formatjs/ecma402-abstract@2.2.0':
-    resolution: {integrity: sha512-IpM+ev1E4QLtstniOE29W1rqH9eTdx5hQdNL8pzrflMj/gogfaoONZqL83LUeQScHAvyMbpqP5C9MzNf+fFwhQ==}
+  '@formatjs/ecma402-abstract@2.2.3':
+    resolution: {integrity: sha512-aElGmleuReGnk2wtYOzYFmNWYoiWWmf1pPPCYg0oiIQSJj0mjc4eUfzUXaSOJ4S8WzI/cLqnCTWjqz904FT2OQ==}
 
-  '@formatjs/fast-memoize@2.2.1':
-    resolution: {integrity: sha512-XS2RcOSyWxmUB7BUjj3mlPH0exsUzlf6QfhhijgI941WaJhVxXQ6mEWkdUFIdnKi3TuTYxRdelsgv3mjieIGIA==}
+  '@formatjs/fast-memoize@2.2.3':
+    resolution: {integrity: sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==}
 
-  '@formatjs/icu-messageformat-parser@2.7.10':
-    resolution: {integrity: sha512-wlQfqCZ7PURkUNL2+8VTEFavPovtADU/isSKLFvDbdFmV7QPZIYqFMkhklaDYgMyLSBJa/h2MVQ2aFvoEJhxgg==}
+  '@formatjs/icu-messageformat-parser@2.9.3':
+    resolution: {integrity: sha512-9L99QsH14XjOCIp4TmbT8wxuffJxGK8uLNO1zNhLtcZaVXvv626N0s4A2qgRCKG3dfYWx9psvGlFmvyVBa6u/w==}
 
-  '@formatjs/icu-skeleton-parser@1.8.4':
-    resolution: {integrity: sha512-LMQ1+Wk1QSzU4zpd5aSu7+w5oeYhupRwZnMQckLPRYhSjf2/8JWQ882BauY9NyHxs5igpuQIXZDgfkaH3PoATg==}
+  '@formatjs/icu-skeleton-parser@1.8.7':
+    resolution: {integrity: sha512-fI+6SmS2g7h3srfAKSWa5dwreU5zNEfon2uFo99OToiLF6yxGE+WikvFSbsvMAYkscucvVmTYNlWlaDPp0n5HA==}
 
   '@formatjs/intl-localematcher@0.5.5':
     resolution: {integrity: sha512-t5tOGMgZ/i5+ALl2/offNqAQq/lfUnKLEw0mXQI4N4bqpedhrSE+fyKLpwnd22sK0dif6AV+ufQcTsKShB9J1g==}
+
+  '@formatjs/intl-localematcher@0.5.7':
+    resolution: {integrity: sha512-GGFtfHGQVFe/niOZp24Kal5b2i36eE2bNL0xi9Sg/yd0TR8aLjcteApZdHmismP5QQax1cMnZM9yWySUUjJteA==}
 
   '@hookform/resolvers@3.9.0':
     resolution: {integrity: sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==}
@@ -2499,8 +2502,8 @@ packages:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
 
-  intl-messageformat@10.7.0:
-    resolution: {integrity: sha512-2P06M9jFTqJnEQzE072VGPjbAx6ZG1YysgopAwc8ui0ajSjtwX1MeQ6bXFXIzKcNENJTizKkcJIcZ0zlpl1zSg==}
+  intl-messageformat@10.7.6:
+    resolution: {integrity: sha512-IsMU/hqyy3FJwNJ0hxDfY2heJ7MteSuFvcnCebxRp67di4Fhx1gKKE+qS0bBwUF8yXkX9SsPUhLeX/B6h5SKUA==}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -2901,8 +2904,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  negotiator@0.6.3:
-    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -2914,11 +2917,11 @@ packages:
       next: ^12 || ^13 || ^14 || >=15.0.0-rc
       react: ^17 || ^18 || >=19.0.0-beta
 
-  next-intl@3.21.1:
-    resolution: {integrity: sha512-hQm4Wgq5i1lfOHAWmXBVl5d2/XAeddcjsrUmjotXEESzPSvW5j2t0Pr8AV8WorTILgqU748aXuenBhz5P78tdw==}
+  next-intl@3.25.0:
+    resolution: {integrity: sha512-xjHNqYyW6LS2Mwmld4Q7tBhyv6g2zO7BtclOAQXe6Fgl5hEsWCv8KNZc0jumud1qnNr8erzmYz8KepJZtXPA4Q==}
     peerDependencies:
-      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0
 
   next-pwa@5.6.0:
     resolution: {integrity: sha512-XV8g8C6B7UmViXU8askMEYhWwQ4qc/XqJGnexbLV68hzKaGHZDMtHsm2TNxFcbR7+ypVuth/wwpiIlMwpRJJ5A==}
@@ -3695,10 +3698,10 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  use-intl@3.21.1:
-    resolution: {integrity: sha512-52kYgcydYkG9SX0ZZGt7W6WD2Va01hwe15bDgkXuaTdSxrF9fDu6hHTV5DxIuSmSSf/FEcBo/nodpw3ZhY31Lw==}
+  use-intl@3.25.0:
+    resolution: {integrity: sha512-e9nfJm18rM+naT14oZZYR3FNWd2mRDmNFQJC4R9qh4vhfabDwl0Kd/B6PodYst7U/0oT3qeKKjlz7qG3BvXAaQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -4698,30 +4701,34 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@formatjs/ecma402-abstract@2.2.0':
+  '@formatjs/ecma402-abstract@2.2.3':
     dependencies:
-      '@formatjs/fast-memoize': 2.2.1
-      '@formatjs/intl-localematcher': 0.5.5
-      tslib: 2.7.0
+      '@formatjs/fast-memoize': 2.2.3
+      '@formatjs/intl-localematcher': 0.5.7
+      tslib: 2.8.1
 
-  '@formatjs/fast-memoize@2.2.1':
+  '@formatjs/fast-memoize@2.2.3':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
-  '@formatjs/icu-messageformat-parser@2.7.10':
+  '@formatjs/icu-messageformat-parser@2.9.3':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.2.0
-      '@formatjs/icu-skeleton-parser': 1.8.4
-      tslib: 2.7.0
+      '@formatjs/ecma402-abstract': 2.2.3
+      '@formatjs/icu-skeleton-parser': 1.8.7
+      tslib: 2.8.1
 
-  '@formatjs/icu-skeleton-parser@1.8.4':
+  '@formatjs/icu-skeleton-parser@1.8.7':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.2.0
-      tslib: 2.7.0
+      '@formatjs/ecma402-abstract': 2.2.3
+      tslib: 2.8.1
 
   '@formatjs/intl-localematcher@0.5.5':
     dependencies:
       tslib: 2.7.0
+
+  '@formatjs/intl-localematcher@0.5.7':
+    dependencies:
+      tslib: 2.8.1
 
   '@hookform/resolvers@3.9.0(react-hook-form@7.52.1(react@18.3.1))':
     dependencies:
@@ -6309,7 +6316,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -6332,8 +6339,8 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -6344,7 +6351,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -6355,7 +6362,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -6365,7 +6372,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -6799,12 +6806,12 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.0.6
 
-  intl-messageformat@10.7.0:
+  intl-messageformat@10.7.6:
     dependencies:
-      '@formatjs/ecma402-abstract': 2.2.0
-      '@formatjs/fast-memoize': 2.2.1
-      '@formatjs/icu-messageformat-parser': 2.7.10
-      tslib: 2.7.0
+      '@formatjs/ecma402-abstract': 2.2.3
+      '@formatjs/fast-memoize': 2.2.3
+      '@formatjs/icu-messageformat-parser': 2.9.3
+      tslib: 2.8.1
 
   invariant@2.2.4:
     dependencies:
@@ -7162,7 +7169,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  negotiator@0.6.3: {}
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -7175,13 +7182,13 @@ snapshots:
       next: 14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6)
       react: 18.3.1
 
-  next-intl@3.21.1(next@14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6))(react@18.3.1):
+  next-intl@3.25.0(next@14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6))(react@18.3.1):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.5
-      negotiator: 0.6.3
+      negotiator: 1.0.0
       next: 14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6)
       react: 18.3.1
-      use-intl: 3.21.1(react@18.3.1)
+      use-intl: 3.25.0(react@18.3.1)
 
   next-pwa@5.6.0(@babel/core@7.25.2)(next@14.2.17(@babel/core@7.25.2)(@opentelemetry/api@1.9.0)(@playwright/test@1.46.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.6))(webpack@5.93.0):
     dependencies:
@@ -8006,10 +8013,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-intl@3.21.1(react@18.3.1):
+  use-intl@3.25.0(react@18.3.1):
     dependencies:
-      '@formatjs/fast-memoize': 2.2.1
-      intl-messageformat: 10.7.0
+      '@formatjs/fast-memoize': 2.2.3
+      intl-messageformat: 10.7.6
       react: 18.3.1
 
   uuid@9.0.1: {}

--- a/src/app/[locale]/(app)/account/page.tsx
+++ b/src/app/[locale]/(app)/account/page.tsx
@@ -1,5 +1,5 @@
 import PageHeader from "@/components/PageHeader";
-import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import AccountSettings from "./_components/AccountSettings";
 
 export async function generateMetadata({
@@ -16,7 +16,7 @@ export default async function Page({
 }: {
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   const t = await getTranslations();
 

--- a/src/app/[locale]/(app)/content/[slug]/page.tsx
+++ b/src/app/[locale]/(app)/content/[slug]/page.tsx
@@ -9,7 +9,7 @@ import { Document } from "@contentful/rich-text-types";
 import renderRichText from "@/lib/renderRichText";
 import "@/styles/content-pages.scss";
 import ContentPage from "../_components/ContentPage";
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import { defaultMetadata } from "@/lib/metadataUtils";
 
 export async function generateStaticParams() {
@@ -47,7 +47,7 @@ export default async function Page({
 }: {
   params: { slug: ContentfulPageKey; locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   const data = await getContent(locale, slug);
   const title = data.fields.title as string;
   const body = data.fields.body as Document;

--- a/src/app/[locale]/(app)/content/contact-us/page.tsx
+++ b/src/app/[locale]/(app)/content/contact-us/page.tsx
@@ -1,5 +1,5 @@
 import ContentPage from "../_components/ContentPage";
-import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import { ALL_LOCALES } from "@/i18n/config";
 import { defaultMetadata } from "@/lib/metadataUtils";
 
@@ -22,7 +22,7 @@ export default async function ContactUs({
 }: {
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(params.locale);
+  setRequestLocale(params.locale);
   const t = await getTranslations("home");
 
   return (

--- a/src/app/[locale]/(app)/content/layout.tsx
+++ b/src/app/[locale]/(app)/content/layout.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 
 export default async function Page({
   params,
@@ -7,6 +7,6 @@ export default async function Page({
   children: React.ReactNode;
   params: { slug: string; locale: string };
 }) {
-  unstable_setRequestLocale(params.locale);
+  setRequestLocale(params.locale);
   return <div style={{ maxWidth: 600, margin: "0 auto" }}>{children}</div>;
 }

--- a/src/app/[locale]/(app)/layout.tsx
+++ b/src/app/[locale]/(app)/layout.tsx
@@ -2,7 +2,7 @@ import Menu from "@/components/Menu/Menu";
 import MobileTabs from "@/components/Menu/MobileTabs";
 import { defaultMetadata } from "@/lib/metadataUtils";
 import { Metadata } from "next";
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import { Container } from "react-bootstrap";
 
 export const metadata: Metadata = defaultMetadata();
@@ -14,7 +14,7 @@ export default async function Layout({
   children: React.ReactNode;
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   return (
     <main className="d-flex flex-column min-vh-100">

--- a/src/app/[locale]/(app)/rate-my-po/agents/new/page.tsx
+++ b/src/app/[locale]/(app)/rate-my-po/agents/new/page.tsx
@@ -1,5 +1,5 @@
 import PageHeader from "@/components/PageHeader";
-import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import officerIcon from "@/../public/images/officer-icon.svg";
 import Image from "next/image";
 import AddAgentForm from "./_components/AddAgentForm";
@@ -9,7 +9,7 @@ export default async function Page({
 }: {
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   const t = await getTranslations();
 
   return (

--- a/src/app/[locale]/(app)/rate-my-po/offices/[officeId]/page.tsx
+++ b/src/app/[locale]/(app)/rate-my-po/offices/[officeId]/page.tsx
@@ -2,7 +2,7 @@ import OfficeInfo from "@/components/OfficeInfo";
 import PageHeader from "@/components/PageHeader";
 import Api from "@/lib/api";
 import Office from "@/types/Office";
-import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import Image from "next/image";
 import { Suspense } from "react";
 import OfficeAgentsSearchBar from "./_components/OfficeAgentsSearchBar";
@@ -28,7 +28,7 @@ export default async function Page({
   params: { officeId: string; locale: string };
   searchParams: { search: string };
 }) {
-  unstable_setRequestLocale(params.locale);
+  setRequestLocale(params.locale);
   const t = await getTranslations();
   const { office } = await new Api()
     .get(`/offices/${params.officeId}`)

--- a/src/app/[locale]/(app)/rate-my-po/page.tsx
+++ b/src/app/[locale]/(app)/rate-my-po/page.tsx
@@ -1,5 +1,5 @@
 import PageHeader from "@/components/PageHeader";
-import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import RateMyPoSearchbar from "./_components/RateMyPoSearchBar";
 import RateMyPoSearchResults from "./_components/RateMyPoSearchResults";
 import { Suspense } from "react";
@@ -31,7 +31,7 @@ export default async function Page({
   };
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   const t = await getTranslations();
 
   return (

--- a/src/app/[locale]/(app)/resources/page.tsx
+++ b/src/app/[locale]/(app)/resources/page.tsx
@@ -1,5 +1,5 @@
 import PageHeader from "@/components/PageHeader";
-import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import ResourcesList from "./_components/ResourcesList";
 import { Suspense } from "react";
 import ResourceSearchBar from "./_components/ResourceSearchBar";
@@ -23,7 +23,7 @@ export default async function Page({
   searchParams: ResourceSearchParams;
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   const t = await getTranslations();
 
   return (

--- a/src/app/[locale]/auth/confirmations/[token]/page.tsx
+++ b/src/app/[locale]/auth/confirmations/[token]/page.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import ConfirmationSpinner from "./_components/ConfirmationSpinner";
 
 export default function Page({
@@ -6,7 +6,7 @@ export default function Page({
 }: {
   params: { token: string; locale: string };
 }) {
-  unstable_setRequestLocale(params.locale);
+  setRequestLocale(params.locale);
 
   return <ConfirmationSpinner token={params.token} />;
 }

--- a/src/app/[locale]/auth/confirmations/page.tsx
+++ b/src/app/[locale]/auth/confirmations/page.tsx
@@ -1,11 +1,11 @@
 import ConfirmEmail from "./_components/ConfirmEmail";
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 
 export default async function Page({
   params: { locale },
 }: {
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   return <ConfirmEmail />;
 }

--- a/src/app/[locale]/auth/forgot-password/page.tsx
+++ b/src/app/[locale]/auth/forgot-password/page.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import ForgotPasswordForm from "./_components/ForgotPasswordForm";
 
 export default async function Page({
@@ -6,6 +6,6 @@ export default async function Page({
 }: {
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   return <ForgotPasswordForm />;
 }

--- a/src/app/[locale]/auth/layout.tsx
+++ b/src/app/[locale]/auth/layout.tsx
@@ -1,6 +1,6 @@
 import { ALL_LOCALES } from "@/i18n/config";
 import AuthLayout from "./_components/AuthLayout";
-import { getLocale, unstable_setRequestLocale } from "next-intl/server";
+import { getLocale, setRequestLocale } from "next-intl/server";
 import { getTranslations } from "next-intl/server";
 
 export async function generateStaticParams() {
@@ -14,7 +14,7 @@ export default async function Layout({
   children: React.ReactNode;
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   const t = await getTranslations();
   return (
     <AuthLayout locale={locale} pageTitle={t("login.loginTitle")}>

--- a/src/app/[locale]/auth/login/page.tsx
+++ b/src/app/[locale]/auth/login/page.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import LoginForm from "./_components/LoginForm";
 
 export default async function Page({
@@ -6,6 +6,6 @@ export default async function Page({
 }: {
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   return <LoginForm />;
 }

--- a/src/app/[locale]/auth/password_resets/[token]/page.tsx
+++ b/src/app/[locale]/auth/password_resets/[token]/page.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import PasswordResetForm from "./_components/PasswordResetForm";
 
 export default async function Page({
@@ -6,6 +6,6 @@ export default async function Page({
 }: {
   params: { token: string; locale: string };
 }) {
-  unstable_setRequestLocale(params.locale);
+  setRequestLocale(params.locale);
   return <PasswordResetForm token={params.token} />;
 }

--- a/src/app/[locale]/auth/signup/page.tsx
+++ b/src/app/[locale]/auth/signup/page.tsx
@@ -1,11 +1,11 @@
 import SignupForm from "@/app/[locale]/auth/signup/_components/SignupForm";
-import { unstable_setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 
 export default async function Page({
   params: { locale },
 }: {
   params: { locale: string };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   return <SignupForm />;
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages, unstable_setRequestLocale } from "next-intl/server";
+import { getMessages, setRequestLocale } from "next-intl/server";
 import { defaultMetadata } from "@/lib/metadataUtils";
 import OriginalPathProvider from "@/components/OriginalPathProvider";
 import Document from "@/components/Document";
@@ -32,7 +32,7 @@ export default async function RootLayout({
   children: React.ReactNode;
   params: { locale: string };
 }>) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   const messages = await getMessages();
 
   return (

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import styles from "@/styles/landing-page.module.scss";
 import { Link } from "@/i18n/routing";
 import { Link as NextIntlLink } from "@/i18n/routing";
@@ -35,7 +35,7 @@ export default async function Page({
 }: {
   params: { locale: Locale };
 }) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
   const t = await getTranslations({ locale });
 
   return (

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,16 +1,20 @@
-import { getRequestConfig } from "next-intl/server";
 import defaultMessages from "../locales/en-US.json";
 import deepmerge from "deepmerge";
-import { notFound } from "next/navigation";
 import { ALL_LOCALES } from "./config";
+import { routing } from "./routing";
+import { getRequestConfig } from "next-intl/server";
 
-export default getRequestConfig(async ({ locale }) => {
-  if (!ALL_LOCALES.includes(locale as any)) {
-    notFound();
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale = await requestLocale;
+
+  if (!locale || !ALL_LOCALES.includes(locale as any)) {
+    locale = routing.defaultLocale;
   }
+
   const localeMessages = (await import(`../locales/${locale}.json`)).default;
 
   return {
+    locale,
     messages: deepmerge(defaultMessages, localeMessages),
   };
 });

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -5,6 +5,7 @@ import { ALL_LOCALES, defaultLocale } from "./config";
 export const routing = defineRouting({
   locales: ALL_LOCALES,
   defaultLocale,
+  alternateLinks: false,
 });
 
 // Should only be used on public routes in the `[locale]` segment

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,4 +1,4 @@
-import { createSharedPathnamesNavigation } from "next-intl/navigation";
+import { createNavigation } from "next-intl/navigation";
 import { defineRouting } from "next-intl/routing";
 import { ALL_LOCALES, defaultLocale } from "./config";
 
@@ -9,4 +9,4 @@ export const routing = defineRouting({
 
 // Should only be used on public routes in the `[locale]` segment
 export const { Link, usePathname, useRouter, redirect } =
-  createSharedPathnamesNavigation(routing);
+  createNavigation(routing);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,7 @@ function removeLocalePrefix(pathname: string) {
   return pathname.replace(/^\/(en|es)/, "");
 }
 
-const intlMiddleware = createMiddleware(routing, { alternateLinks: false });
+const intlMiddleware = createMiddleware(routing);
 export async function middleware(request: NextRequest) {
   if (AUTH_REQUIRED.includes(removeLocalePrefix(request.nextUrl.pathname))) {
     const user = await getUser();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,17 +8,11 @@ const AUTH_REDIRECTS = ["/auth/login", "/auth/signup", "/auth/forgot-password"];
 const AUTH_REQUIRED = ["/account", "/rate-my-po/new"];
 
 function removeLocalePrefix(pathname: string) {
-  return pathname.replace(/^\/(en-US|es-MX)/, "");
+  return pathname.replace(/^\/(en|es)/, "");
 }
 
 const intlMiddleware = createMiddleware(routing, { alternateLinks: false });
 export async function middleware(request: NextRequest) {
-  if (request.nextUrl.pathname === "/") {
-    const locale = request.headers.get("accept-language")?.split(",")[0];
-    return NextResponse.redirect(
-      new URL(`/${locale ?? defaultLocale}`, request.url)
-    );
-  }
   if (AUTH_REQUIRED.includes(removeLocalePrefix(request.nextUrl.pathname))) {
     const user = await getUser();
     if (!user) {


### PR DESCRIPTION
Updating to latest next-intl so eventual upgrade to nextjs 15 goes smoothly.

## 🛠️ Changes
Update a number of next-intl APIs to the latest recommended usages. [Details here](https://next-intl-docs.vercel.app/blog/next-intl-3-22).


## 🧪 Testing
General clickthroughs would be good. Particularly, language switching, signing in/out, noticing redirects, etc.
