### PR TITLE
Adding a PartnersFooter that only displays on What is page

### DIFF
--- a/src/app/[locale]/(app)/content/[slug]/page.tsx
+++ b/src/app/[locale]/(app)/content/[slug]/page.tsx
@@ -1,5 +1,3 @@
-// note spanish locale in contentful is es-US
-
 import { ALL_LOCALES } from "@/i18n/config";
 import ContentfulClient, {
   ContentfulPageKey,
@@ -35,6 +33,7 @@ export async function generateMetadata({
 }
 
 async function getContent(locale: string, slug: ContentfulPageKey) {
+  // note spanish locale in contentful is es-US
   const contentfulLocale = locale === "es-MX" ? "es-US" : locale;
   const data = await ContentfulClient.getEntry(contentfulPageIds[slug], {
     locale: contentfulLocale,

--- a/src/app/[locale]/(app)/content/_components/PartnersCard.tsx
+++ b/src/app/[locale]/(app)/content/_components/PartnersCard.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { CldImage } from "next-cloudinary";
+import { Col } from "react-bootstrap";
+
+export default function PartnersCard({
+  src,
+  label,
+  alt,
+}: {
+  src: string;
+  label: string;
+  alt: string;
+}) {
+  return (
+    <Col md className="text-center">
+      <div className="position-relative mb-3">
+        <CldImage
+          src={src}
+          width="100"
+          height="100"
+          alt={alt}
+          style={{ maxWidth: 100, objectFit: "contain", alignSelf: "center" }}
+        />
+      </div>
+      <h4 className="text-white">{label}</h4>
+    </Col>
+  );
+}

--- a/src/app/[locale]/(app)/content/_components/PartnersFooter.tsx
+++ b/src/app/[locale]/(app)/content/_components/PartnersFooter.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { CldImage } from "next-cloudinary";
+import { useTranslations } from "next-intl";
+import { usePathname } from "next/navigation";
+
+export default function PartnersFooter() {
+  const p = usePathname();
+  const t = useTranslations("navigation");
+  if (!p.endsWith("/content/what-is-project-protocol")) return null;
+  return (
+    <div className="bg-black text-center mt-auto py-md-4 pt-4 pb-5">
+      <div className="container" style={{ maxWidth: 1048 }}>
+        <h2 className="text-white mt-3 mb-5">{t("partners")}</h2>
+        <div className="row align-items-center justify-content-center">
+          <div className="col-sm text-center">
+            <div className="position-relative">
+              <CldImage
+                src="emergent_works_ppi"
+                width="100"
+                height="100"
+                alt="Emergent Works logo"
+                style={{
+                  maxWidth: 100,
+                  objectFit: "contain",
+                  alignSelf: "center",
+                }}
+              />
+            </div>
+            <h4 className="text-white mt-4">Emergent Works</h4>
+          </div>
+          <div className="col-sm text-center">
+            <div className="position-relative">
+              <CldImage
+                src="reimagine_freedom_ppi"
+                width="100"
+                height="100"
+                alt="Reimagine Freedom logo"
+                style={{
+                  maxWidth: 100,
+                  objectFit: "contain",
+                  alignSelf: "center",
+                }}
+              />
+            </div>
+            <h4 className="text-white mt-1">Reimagine Freedom</h4>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(app)/content/_components/PartnersFooter.tsx
+++ b/src/app/[locale]/(app)/content/_components/PartnersFooter.tsx
@@ -1,7 +1,9 @@
 "use client";
-import { CldImage } from "next-cloudinary";
 import { useTranslations } from "next-intl";
 import { usePathname } from "@/i18n/routing";
+import { Container, Row } from "react-bootstrap";
+import PartnersCard from "./PartnersCard";
+import { MENU_MAX_WIDTH } from "@/components/Menu/Menu";
 
 export default function PartnersFooter() {
   const p = usePathname();
@@ -9,43 +11,21 @@ export default function PartnersFooter() {
   if (!p.endsWith("/content/what-is-project-protocol")) return null;
   return (
     <div className="bg-black text-center mt-auto py-md-4 pt-4 pb-5">
-      <div className="container" style={{ maxWidth: 1048 }}>
+      <Container style={{ maxWidth: MENU_MAX_WIDTH }}>
         <h2 className="text-white mt-3 mb-5">{t("partners")}</h2>
-        <div className="row align-items-center justify-content-center">
-          <div className="col-sm text-center">
-            <div className="position-relative">
-              <CldImage
-                src="emergent_works_ppi"
-                width="100"
-                height="100"
-                alt="Emergent Works logo"
-                style={{
-                  maxWidth: 100,
-                  objectFit: "contain",
-                  alignSelf: "center",
-                }}
-              />
-            </div>
-            <h4 className="text-white mt-4">Emergent Works</h4>
-          </div>
-          <div className="col-sm text-center">
-            <div className="position-relative">
-              <CldImage
-                src="reimagine_freedom_ppi"
-                width="100"
-                height="100"
-                alt="Reimagine Freedom logo"
-                style={{
-                  maxWidth: 100,
-                  objectFit: "contain",
-                  alignSelf: "center",
-                }}
-              />
-            </div>
-            <h4 className="text-white mt-1">Reimagine Freedom</h4>
-          </div>
-        </div>
-      </div>
+        <Row>
+          <PartnersCard
+            src="emergent_works_ppi"
+            label="Emergent Works"
+            alt="Emergent Works logo"
+          />
+          <PartnersCard
+            src="reimagine_freedom_ppi"
+            label="Reimagine Freedom"
+            alt="Reimagine Freedom logo"
+          />
+        </Row>
+      </Container>
     </div>
   );
 }

--- a/src/app/[locale]/(app)/content/_components/PartnersFooter.tsx
+++ b/src/app/[locale]/(app)/content/_components/PartnersFooter.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { CldImage } from "next-cloudinary";
 import { useTranslations } from "next-intl";
-import { usePathname } from "next/navigation";
+import { usePathname } from "@/i18n/routing";
 
 export default function PartnersFooter() {
   const p = usePathname();

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import PartnersFooter from "@/app/[locale]/(app)/content/_components/PartnersFooter";
 import { Link } from "@/i18n/routing";
 import { getTranslations } from "next-intl/server";
 
@@ -54,29 +55,32 @@ export default async function Footer() {
   ];
 
   return (
-    <div className="bg-dark text-center mt-auto py-md-4 pt-4 pb-5 mb-5 mb-md-0">
-      {links.map(({ label, url, target }) => (
-        <Link
-          key={`footer-link-${label}`}
-          className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
-          href={url}
-          target={target || "_self"}
-        >
-          {label}
-        </Link>
-      ))}
-      <span className="d-flex flex-wrap justify-content-center my-3">
-        {socialMediaLinks.map(({ url, icon }) => (
-          <a
-            key={`social-link-${icon}`}
-            href={url}
-            target="_blank"
+    <>
+      <PartnersFooter />
+      <div className="bg-dark text-center mt-auto py-md-4 pt-4 pb-5 mb-5 mb-md-0">
+        {links.map(({ label, url, target }) => (
+          <Link
+            key={`footer-link-${label}`}
             className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
+            href={url}
+            target={target || "_self"}
           >
-            <i className={`bi bi-${icon} fs-1`}></i>
-          </a>
+            {label}
+          </Link>
         ))}
-      </span>
-    </div>
+        <span className="d-flex flex-wrap justify-content-center my-3">
+          {socialMediaLinks.map(({ url, icon }) => (
+            <a
+              key={`social-link-${icon}`}
+              href={url}
+              target="_blank"
+              className="mx-3 my-3 d-block d-md-inline text-center link-white link-underline-opacity-0"
+            >
+              <i className={`bi bi-${icon} fs-1`}></i>
+            </a>
+          ))}
+        </span>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## 🛠️ Changes

This adds a footer with our partners and logos that have been added to Cloudinary.

## 🧪 Testing

Not the best at CSS or styling, so would like some help on the desktop version of this.
<img width="375" alt="Screenshot 2024-11-20 at 12 29 28 PM" src="https://github.com/user-attachments/assets/91daa309-e089-41ba-9b35-8ccbb45bb9af">

