### PR TITLE
Add back app title to app menu

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -10,7 +10,6 @@ import MenuLink from "./MenuLink";
 import { useLocale, useTranslations } from "next-intl";
 import { useAuth } from "../AuthProvider";
 import { Link } from "@/i18n/routing";
-import styles from "@/styles/landing-page.module.scss";
 
 export const MENU_MAX_WIDTH = 1048;
 
@@ -49,15 +48,17 @@ export default function Menu() {
             >
               <Image
                 priority
-                unoptimized
-                src={"/images/icon.svg"}
+                src="/images/icon.svg"
                 width="0"
                 height="0"
                 className="me-2"
                 style={{ width: 28, height: 28 }}
                 alt={"Project Protocol logo"}
               />
-              <span className="fs-2 w-100 d-md-inline fw-semibold pe-auto text-white text-md-black">
+              <span
+                className="fs-2 w-100 d-none d-md-inline fw-semibold pe-auto text-white text-md-black"
+                style={{ letterSpacing: -0.5 }}
+              >
                 Project Protocol
               </span>
             </div>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -10,6 +10,7 @@ import MenuLink from "./MenuLink";
 import { useLocale, useTranslations } from "next-intl";
 import { useAuth } from "../AuthProvider";
 import { Link } from "@/i18n/routing";
+import styles from "@/styles/landing-page.module.scss";
 
 export const MENU_MAX_WIDTH = 1048;
 
@@ -36,7 +37,6 @@ export default function Menu() {
           </div>
         </Container>
       </div>
-
       <div className="w-100 d-block bg-black bg-md-white">
         <Container
           style={{ maxWidth: MENU_MAX_WIDTH }}
@@ -57,6 +57,9 @@ export default function Menu() {
                 style={{ width: 28, height: 28 }}
                 alt={"Project Protocol logo"}
               />
+              <span className="fs-2 w-100 d-md-inline fw-semibold pe-auto text-white text-md-black">
+                Project Protocol
+              </span>
             </div>
           </NavbarBrand>
           <Nav className="fs-4 d-none d-md-flex align-items-center gap-2 fw-semibold">


### PR DESCRIPTION
- **Fix navbar brand in main views for desktop**
- **Add back desktop brand to non-home page menu**

## 🛠️ Changes
App title shows in menu for desktop views, but goes away on mobile screens

## 🧪 Testing
[See preview](https://preview-83.staging.projectprotocol.org/)


## 📷 Screens

Desktop
---
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/feb877bf-6dbe-4f53-a420-9f69424968e5">

Mobile
---
<img width="486" alt="image" src="https://github.com/user-attachments/assets/6b4c2733-6102-4aab-8bc0-0444f4c6e1c2">

