### PR TITLE
Allow Contentful to publish live changes

### DIFF
--- a/src/app/[locale]/(app)/content/_components/TeamMember.tsx
+++ b/src/app/[locale]/(app)/content/_components/TeamMember.tsx
@@ -5,20 +5,13 @@ import { Col, Row, Collapse } from "react-bootstrap";
 import { useState } from "react";
 import renderRichText from "@/lib/renderRichText";
 import { Document } from "@contentful/rich-text-types";
+import { ContentfulTeamMember } from "@/lib/contentful/team-member";
 
 export interface TeamMemberProps {
-  name: string;
-  title: string;
-  bio: Document;
-  imgId: string;
+  teamMember: ContentfulTeamMember;
 }
 
-export default function TeamMember({
-  name,
-  title,
-  bio,
-  imgId,
-}: TeamMemberProps) {
+export default function TeamMember({ teamMember }: TeamMemberProps) {
   const [showBio, setShowBio] = useState(false);
   const handleBio = () => {
     setShowBio(!showBio);
@@ -29,10 +22,10 @@ export default function TeamMember({
         <Col xs={4} sm={3} className="text-left">
           <div className="position-relative">
             <CldImage
-              src={imgId}
+              src={teamMember.cloudinaryId}
               width="100"
               height="100"
-              alt={name}
+              alt={teamMember.name}
               style={{
                 maxWidth: 100,
                 objectFit: "cover",
@@ -44,12 +37,12 @@ export default function TeamMember({
           </div>
         </Col>
         <Col xs={8} sm={9} className="text-left">
-          <h2 className="mb-1">{name}</h2>
-          <p className="my-0 py-0">{title}</p>
+          <h2 className="mb-1">{teamMember.name}</h2>
+          <p className="my-0 py-0">{teamMember.jobTitle}</p>
         </Col>
       </Row>
       <Collapse in={showBio}>
-        <div>{renderRichText(bio)}</div>
+        <div>{renderRichText(teamMember.bio.json)}</div>
       </Collapse>
     </>
   );

--- a/src/app/[locale]/(app)/content/_components/TeamMemberList.tsx
+++ b/src/app/[locale]/(app)/content/_components/TeamMemberList.tsx
@@ -1,27 +1,15 @@
-import { getContentfulType } from "@/lib/contentful";
-import { Document } from "@contentful/rich-text-types";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Container } from "react-bootstrap";
-import TeamMember, { TeamMemberProps } from "./TeamMember";
+import TeamMember from "./TeamMember";
+import {
+  ContentfulTeamMember,
+  getTeamMembers,
+} from "@/lib/contentful/team-member";
+import { groupBy } from "lodash";
 
 async function getTeamMemberProps(locale: string) {
-  const people: { [key: string]: TeamMemberProps[] } = {
-    team_member: [],
-    board_member: [],
-    founder: [],
-  };
-
-  const data = await getContentfulType("teamMember", locale);
-  data.items.forEach((item) => {
-    const role = item.fields.role as "team_member" | "board_member" | "founder";
-    people[role].push({
-      name: item.fields.name as string,
-      title: item.fields.jobTitle as string,
-      bio: item.fields.bio as Document,
-      imgId: item.fields.cloudinaryId as string,
-    });
-  });
-  return people;
+  const teamMembers = await getTeamMembers(locale);
+  return groupBy(teamMembers, "role");
 }
 
 export default async function TeamMemberList({ locale }: { locale: string }) {
@@ -36,17 +24,17 @@ export default async function TeamMemberList({ locale }: { locale: string }) {
   return (
     <Container className="vertical-rhythm">
       <h3>{t("theTeam.boardMembers")}</h3>
-      {board_member.map((props: TeamMemberProps) => (
-        <TeamMember key={props.name} {...props} />
+      {board_member.map((t: ContentfulTeamMember) => (
+        <TeamMember key={t.name} teamMember={t} />
       ))}
       <hr />
       <h3>{t("theTeam.founder")}</h3>
-      {founder.map((props: TeamMemberProps) => (
-        <TeamMember key={props.name} {...props} />
+      {founder.map((t: ContentfulTeamMember) => (
+        <TeamMember key={t.name} teamMember={t} />
       ))}
       <hr />
-      {team_member.map((props: TeamMemberProps) => (
-        <TeamMember {...props} key={props.name} />
+      {team_member.map((t: ContentfulTeamMember) => (
+        <TeamMember key={t.name} teamMember={t} />
       ))}
     </Container>
   );

--- a/src/app/api/revalidation/route.ts
+++ b/src/app/api/revalidation/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+
+export async function POST(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers);
+  const secret = requestHeaders.get("x-contentful-reval-key");
+  const tag = request.nextUrl.searchParams.get("tag");
+
+  if (secret !== process.env.CONTENTFUL_REVALIDATE_SECRET) {
+    return NextResponse.json({ message: "Invalid secret" }, { status: 401 });
+  }
+
+  if (!tag) {
+    return NextResponse.json({ message: "Missing tag" }, { status: 400 });
+  }
+
+  revalidateTag(tag);
+
+  return NextResponse.json({ revalidated: true, now: Date.now() });
+}

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -1,22 +1,11 @@
 import { createClient } from "contentful";
 
-export const contentfulPageIds = {
-  about: "01l6lbfvmtbqQHjt7LuUFL",
-  "the-team": "41UOkLNQQfa6pK2U7Gr46d",
-  "why-email": "6K61ZF3VLMPMi0BjOQ3gjk",
-  "ethical-principles": "6UFa3N1g7ytcAxeBCQVyTY",
-  vote: "6VgcyUQKmZTr955WYmlhr8",
-  "terms-of-service": "1acLWVokjkixcvTh0b3gup",
-  "community-posting-guidelines": "fYYpah3B5mppvE7rXY1gY",
-  "what-is-project-protocol": "1Is9QM4ez0YDMYktRuuJZx",
-  "how-it-works": "1BQDLK4P2L1E0DmCwLOrDR",
-};
-
-export type ContentfulPageKey = keyof typeof contentfulPageIds;
-
+const SPACE_ID = "zwkgwua3qde9";
+const ACCESS_TOKEN = "kKEOXwvZcsASfym1i7BjO-g65KX5esCTa08w9rGHYBg";
+const GRAPHQL_URL = `https://graphql.contentful.com/content/v1/spaces/${SPACE_ID}`;
 const client = createClient({
-  space: "zwkgwua3qde9",
-  accessToken: "kKEOXwvZcsASfym1i7BjO-g65KX5esCTa08w9rGHYBg",
+  space: SPACE_ID,
+  accessToken: ACCESS_TOKEN,
 });
 
 const ContentfulClient = {
@@ -25,22 +14,27 @@ const ContentfulClient = {
   getTags: client.getTags,
 };
 
+export const contentfulLocale = (locale: string) =>
+  locale === "es-MX" ? "es-US" : locale;
+
 export default ContentfulClient;
 
 export async function getContentfulType(type: string, locale: string) {
-  const contentfulLocale = locale === "es-MX" ? "es-US" : locale;
   const data = await ContentfulClient.getEntries({
     content_type: type,
-    locale: contentfulLocale,
+    locale: contentfulLocale(locale),
   });
   return data;
 }
 
-export async function getContent(locale: string, slug: ContentfulPageKey) {
-  // note spanish locale in contentful is es-US
-  const contentfulLocale = locale === "es-MX" ? "es-US" : locale;
-  const data = await ContentfulClient.getEntry(contentfulPageIds[slug], {
-    locale: contentfulLocale,
-  });
-  return data;
+export async function fetchGraphQL(query: string, cacheKeys: string[]) {
+  return fetch(GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+    },
+    body: JSON.stringify({ query }),
+    next: { tags: cacheKeys },
+  }).then((response) => response.json());
 }

--- a/src/lib/contentful/document.ts
+++ b/src/lib/contentful/document.ts
@@ -1,0 +1,61 @@
+import { Document } from "@contentful/rich-text-types";
+import { contentfulLocale, fetchGraphQL } from "../contentful";
+
+export const DOCUMENT_GRAPHQL_FIELDS = `
+  sys {
+    id
+  }
+  title
+  slug
+  cloudinaryImgId
+  body {
+    json
+  }
+`;
+
+export type ContentfulDocument = {
+  sys: {
+    id: string;
+  };
+  title: string;
+  slug: string;
+  cloudinaryImgId: string;
+  body: {
+    json: Document;
+  };
+};
+
+export const getDocumentQuery = (slug: string, locale: string) => `
+  query {
+    documentCollection(limit: 1, locale: "${locale}", where: { slug: "${slug}"}) {
+      items {
+        ${DOCUMENT_GRAPHQL_FIELDS}
+      }
+    }
+  }
+`;
+
+export const ALL_DOCUMENTS_QUERY = `
+  query {
+    documentCollection {
+      items {
+        ${DOCUMENT_GRAPHQL_FIELDS}
+      }
+    }
+  }
+`;
+
+export async function getDocuments() {
+  const response = await fetchGraphQL(ALL_DOCUMENTS_QUERY, ["document"]);
+  return response.data.documentCollection.items;
+}
+
+export async function getDocument(
+  slug: string,
+  locale = "en-US"
+): Promise<ContentfulDocument> {
+  const query = getDocumentQuery(slug, contentfulLocale(locale));
+  const response = await fetchGraphQL(query, ["document"]);
+  const document = response.data.documentCollection.items[0];
+  return document;
+}

--- a/src/lib/contentful/team-member.ts
+++ b/src/lib/contentful/team-member.ts
@@ -1,0 +1,47 @@
+import { Document } from "@contentful/rich-text-types";
+import { contentfulLocale, fetchGraphQL } from "../contentful";
+
+export const TEAM_MEMBER_GRAPHQL_FIELDS = `
+  sys {
+    id
+  }
+  name
+  jobTitle
+  cloudinaryId
+  role
+  bio {
+    json
+  }
+`;
+
+export type ContentfulTeamMember = {
+  sys: {
+    id: string;
+  };
+  name: string;
+  jobTitle: string;
+  role: "team_member" | "board_member" | "founder";
+  cloudinaryId: string;
+  bio: {
+    json: Document;
+  };
+};
+
+const allTeamMembersQuery = (locale: string) => `
+  query {
+    teamMemberCollection(locale: "${locale}") {
+      items {
+        ${TEAM_MEMBER_GRAPHQL_FIELDS}
+      }
+    }
+  }
+`;
+
+export async function getTeamMembers(
+  locale: string
+): Promise<ContentfulTeamMember[]> {
+  const query = allTeamMembersQuery(contentfulLocale(locale));
+  const response = await fetchGraphQL(query, ["teamMember"]);
+  const data = response.data.teamMemberCollection.items;
+  return data;
+}


### PR DESCRIPTION
## 🛠️ Changes
Simplifies contentful implementation to make it more dynamic (no hard-coded slugs or IDs). Source of truth for page slugs and what pages exist is now in contentful.

Adds a revalidation route to the API which clears the cache for a particular document type (document or teamMember).
* e.g. `POST <host>/api/revalidate?tag=document`
* Requires `x-contentful-reval-key` header
* Accepts a `?tag=` parameter.

This endpoint is used by Contentful via Webhook to trigger a cache invalidation when a document or team member change is published.

